### PR TITLE
Handled caption files that are not providing microsecond precision.

### DIFF
--- a/pycaption/dfxp.py
+++ b/pycaption/dfxp.py
@@ -71,6 +71,8 @@ class DFXPReader(BaseReader):
 
     def _translate_time(self, stamp):
         timesplit = stamp.split(':')
+        if not '.' in timesplit[2]:
+            timesplit[2] = timesplit[2] + '.000'
         secsplit = timesplit[2].split('.')
         if len(timesplit) > 3:
             secsplit.append((int(timesplit[3]) / 30) * 100)

--- a/pycaption/srt.py
+++ b/pycaption/srt.py
@@ -38,6 +38,8 @@ class SRTReader(BaseReader):
 
     def _srttomicro(self, stamp):
         timesplit = stamp.split(':')
+        if not ',' in timesplit[2]:
+            timesplit[2] = timesplit[2] + ',000'
         secsplit = timesplit[2].split(',')
         microseconds = (int(timesplit[0]) * 3600000000 +
                         int(timesplit[1]) * 60000000 +


### PR DESCRIPTION
Hey there, 

There where several complains from the QA team that are some conversion errors received from some particular files. What I discovered is that the caption content is correct but some captions (dfxp and srt in this case) are not providing microseconds information, so there where errors trying to extract the microseconds. Based on observation I assumed that is correct to set 000 as microseconds to not interfere whit the rest of the logic. Correct me if I'm wrong.

Here are the files used for testing:
http://s3.amazonaws.com/pbs.merlin.cdn.prod/Video%20Asset/KLVX/vegas-pbs-documentaries/65282/captions/19237_SRT_INED1307H.srt 
http://s3.amazonaws.com/pbs.merlin.cdn.prod/Video%20Asset/WNET/metrofocus/66598/captions/21059_DFXP_mefo-000308.dfxp 

Thanks,
Calin
