### PR TITLE
Don't bother building version 2.6, because 'beautifulsoup4' (a dependenc...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - 2.6
     - 2.7
 
 script: python setup.py test


### PR DESCRIPTION
Don't bother building version 2.6 with Travis CI, because 'beautifulsoup4' (a dependency) already requires python 2.7 anyway. (Also, fixes a build breakage in another branch.)
