### PR TITLE
SRTReader: Skip unexpected line instead of failing

### DIFF
--- a/pycaption/srt.py
+++ b/pycaption/srt.py
@@ -21,7 +21,8 @@ class SRTReader(BaseReader):
 
         while start_line < len(lines):
             if not lines[start_line].isdigit():
-                break
+                start_line += 1
+                continue
 
             caption = Caption()
 


### PR DESCRIPTION
Because of the unstructured nature of SRT it is more vulnerable to
corruption than other subtitle formats. Sometimes there will be more than
one empty line between two queues in a SRT subtitle, or a queue will be
missing sequence number.

Pycaption fails immediately for such input. Instead, it should make best
effort, i. e. ignore such line and continue with the hope that the rest of
the file will be valid.
