### PR TITLE
Handle empty cues in WebVTT text

### DIFF
--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -54,13 +54,10 @@ class WebVTTReader(BaseReader):
 
             elif '' == line:
                 if found_timing:
-                    if caption.is_empty():
-                        raise CaptionReadSyntaxError(
-                            'Cue without content. (line %d)' % timing_line)
-                    else:
-                        found_timing = False
+                    found_timing = False
+                    if not caption.is_empty():
                         captions.append(caption)
-                        caption = None
+                    caption = None
             else:
                 if found_timing:
                     if not caption.is_empty():

--- a/tests/samples.py
+++ b/tests/samples.py
@@ -626,3 +626,12 @@ When we think
 of "E equals m c-squared",
 
 """
+
+SAMPLE_WEBVTT_EMPTY_CUE = """WEBVTT
+
+1
+00:00.000 --> 00:02.000
+
+00:04.000 --> 00:05.000
+Transcribed by Celestials
+"""

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -85,6 +85,10 @@ class WebVTTReaderTestCase(unittest.TestCase):
             """
         )
 
+    def test_webvtt_empty_cue(self):
+        self.assertEqual(1, len(self.reader.read(
+                SAMPLE_WEBVTT_EMPTY_CUE).get_captions('en-US')))
+
 
 class WebVTTWriterTestCase(unittest.TestCase):
 


### PR DESCRIPTION
This is a fix for https://github.com/pbs/pycaption/issues/42. To the best of my knowledge, this does not improve / worsen the existing spec-compliance issue as reported [here](https://github.com/pbs/pycaption/issues/44). This also adds a test for the new code path.
