### PR TITLE
line breaks for webvtt (and srt) now agree better with the specs.

### DIFF
--- a/pycaption/sami.py
+++ b/pycaption/sami.py
@@ -87,7 +87,10 @@ class SAMIReader(BaseReader):
     def _translate_tag(self, tag):
         # convert text
         if isinstance(tag, NavigableString):
-            self.line.append(CaptionNode.create_text(tag.strip()))
+            text = tag.strip()
+            if not text:
+                return
+            self.line.append(CaptionNode.create_text(text))
         # convert line breaks
         elif tag.name == u'br':
             self.line.append(CaptionNode.create_break())

--- a/pycaption/srt.py
+++ b/pycaption/srt.py
@@ -99,10 +99,16 @@ class SRTWriter(BaseWriter):
             timestamp = u'%s --> %s\n' % (start[:12], end[:12])
 
             srt += timestamp.replace(u'.', u',')
-            for node in caption.nodes:
-                srt = self._recreate_line(srt, node)
 
-            srt += u'\n\n'
+            new_content = u''
+            for node in caption.nodes:
+                new_content = self._recreate_line(new_content, node)
+
+            # Eliminate excessive line breaks
+            new_content = new_content.strip()
+            new_content.replace(u'\n\n', u'\n')
+
+            srt += u"%s%s" % (new_content, u'\n\n')
             count += 1
 
         return srt[:-1]  # remove unwanted newline at end of file

--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -39,10 +39,10 @@ class WebVTTReader(BaseReader):
     def _parse(self, lines):
         captions = []
         caption = None
-
         found_timing = False
 
         for i, line in enumerate(lines):
+
             if u'-->' in line:
                 found_timing = True
                 timing_line = i
@@ -163,16 +163,23 @@ class WebVTTWriter(BaseWriter):
         end = self._timestamp(sub.end)
 
         output = u"%s --> %s\n" % (start, end)
+
         output += self._convert_nodes(sub.nodes)
         output += u'\n'
 
         return output
 
     def _convert_nodes(self, nodes):
+        """Convert a Caption's nodes to text.
+        """
+        if not nodes:
+            return u'&nbsp;'
+
         s = u''
+
         for i, node in enumerate(nodes):
             if node.type == CaptionNode.TEXT:
-                s += node.content
+                s += node.content or u'&nbsp;'
             elif node.type == CaptionNode.STYLE:
                 # TODO: Ignoring style so far.
                 pass

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
 
 setup(
     name='pycaption',
-    version='0.4.0',
+    version='0.4.1',
     description='Closed caption converter',
     long_description=open(README_PATH).read(),
     author='Joe Norton',

--- a/tests/samples.py
+++ b/tests/samples.py
@@ -126,6 +126,9 @@ P { margin-left:  1pt;
     of "E equals m c-squared",
 </P></SYNC>
 <SYNC start="17000"><P class="ENCC">
+
+
+
   <SPAN Style="text-align:right;">we have this vision of Einstein</SPAN>
 </P></SYNC>
 <SYNC start="18752"><P class="ENCC">
@@ -144,6 +147,10 @@ P { margin-left:  1pt;
 <SYNC start="32200"><P class="ENCC">
     &lt;LAUGHING &amp; WHOOPS!&gt;
 </P></SYNC>
+<SYNC start="34400">
+<P class="ENCC"><br/>some more text
+</P>
+</SYNC>
 </BODY></SAMI>
 """
 
@@ -312,8 +319,12 @@ MAN 2:
 It's all about an eternal Einstein.
 
 7
-00:00:32,200 --> 00:00:36,200
+00:00:32,200 --> 00:00:34,400
 <LAUGHING & WHOOPS!>
+
+8
+00:00:34,400 --> 00:00:38,400
+some more text
 """
 
 
@@ -541,9 +552,10 @@ SAMPLE_DFXP = """
     MAN 2:<br/>
     It's all about an eternal Einstein.
    </p>
-   <p begin="00:00:32.200" end="00:00:36.200" style="p">
+   <p begin="00:00:32.200" end="00:00:34.400" style="p">
     &lt;LAUGHING &amp; WHOOPS!&gt;
    </p>
+   <p begin="00:00:34.400" end="00:00:38.400" style="p">some more text</p>
   </div>
  </body>
 </tt>"""

--- a/tests/test_dfxp.py
+++ b/tests/test_dfxp.py
@@ -12,8 +12,7 @@ class DFXPReaderTestCase(unittest.TestCase):
 
     def test_caption_length(self):
         captions = DFXPReader().read(SAMPLE_DFXP.decode(u'utf-8'))
-
-        self.assertEquals(7, len(captions.get_captions(u"en-US")))
+        self.assertEquals(8, len(captions.get_captions(u"en-US")))
 
     def test_proper_timestamps(self):
         captions = DFXPReader().read(SAMPLE_DFXP.decode(u'utf-8'))

--- a/tests/test_sami.py
+++ b/tests/test_sami.py
@@ -13,7 +13,7 @@ class SAMIReaderTestCase(unittest.TestCase):
     def test_caption_length(self):
         captions = SAMIReader().read(SAMPLE_SAMI.decode(u'utf-8'))
 
-        self.assertEquals(7, len(captions.get_captions(u"en-US")))
+        self.assertEquals(8, len(captions.get_captions(u"en-US")))
 
     def test_proper_timestamps(self):
         captions = SAMIReader().read(SAMPLE_SAMI.decode(u'utf-8'))

--- a/tests/test_srt.py
+++ b/tests/test_srt.py
@@ -13,7 +13,7 @@ class SRTReaderTestCase(unittest.TestCase):
     def test_caption_length(self):
         captions = SRTReader().read(SAMPLE_SRT.decode(u'utf-8'))
 
-        self.assertEquals(7, len(captions.get_captions(u"en-US")))
+        self.assertEquals(8, len(captions.get_captions(u"en-US")))
 
     def test_proper_timestamps(self):
         captions = SRTReader().read(SAMPLE_SRT.decode(u'utf-8'))


### PR DESCRIPTION
Because the in the webvtt format, line breaks are part of the syntax,
when converting a CaptionSet to a webvtt, we will be converting extra
line breaks into the &nbsp; symbol. This also has the advantage of being
very explicit and visible.

Same for SRT files - they were vulnerable to having their syntax broken by too many line breaks, for which other formats don't have anything against.
