### PR TITLE
Ignoring timing errors for the generated WebVTT files

### DIFF
--- a/pycaption/base.py
+++ b/pycaption/base.py
@@ -33,6 +33,9 @@ class CaptionConverter(object):
 
 
 class BaseReader(object):
+    def __init__(self, *args, **kwargs):
+        pass
+
     def detect(self, content):
         if content:
             return True

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ dependencies = [
 
 setup(
     name='pycaption',
-    version='0.4.4',
+    version='0.4.5',
     description='Closed caption converter',
     long_description=open(README_PATH).read(),
     author='Joe Norton',


### PR DESCRIPTION
Also, added explicit option of not ignoring them (parameter ignore_timing_errors) to the WebVTTReader initializer.
