### PR TITLE
* Fixes issue #68 by setting defaults at the level of the Padding class

### DIFF
--- a/pycaption/geometry.py
+++ b/pycaption/geometry.py
@@ -519,6 +519,9 @@ class Padding(object):
     """Represents padding information. Consists of 4 Size objects, representing
     padding from (in this order): before (up), after (down), start (left) and
     end (right).
+
+    A valid Padding object must always have all paddings set and different from
+    None. If this is not true Writers may fail for they rely on this assumption.
     """
     def __init__(self, before=None, after=None, start=None, end=None):
         """
@@ -531,6 +534,13 @@ class Padding(object):
         self.after = after
         self.start = start
         self.end = end
+
+        for attr in ['before', 'after', 'start', 'end']:
+            # Ensure that a Padding object always explicitly defines all
+            # four possible paddings
+            if getattr(self, attr) is None:
+                # Sets default padding (0%)
+                setattr(self, attr, Size(0, UnitEnum.PERCENT))
 
     @classmethod
     def from_xml_attribute(cls, attribute):
@@ -624,6 +634,9 @@ class Padding(object):
                     string_list.append(
                         getattr(self, attrib).to_xml_attribute())
         except AttributeError:
+            # A Padding object with attributes set to None is considered
+            # invalid. All four possible paddings must be set. If one of them
+            # is not, this error is raised.
             raise ValueError(u"The attribute order specified is invalid.")
 
         return u' '.join(string_list)

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -225,3 +225,20 @@ SAMPLE_SAMI_DOUBLE_BR = """
     of "E equals m c-squared",
 </BODY></SAMI>
 """
+
+SAMPLE_SAMI_PARTIAL_MARGINS = u"""
+<SAMI>
+<HEAD>
+   <STYLE TYPE="Text/css">
+   <!--
+      P {margin-left: 29pt; margin-right: 29pt; font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
+      .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC;}
+   -->
+   </STYLE>
+</HEAD>
+<BODY>
+   <SYNC START=133>
+      <P CLASS=SUBTTL>>> COMING UP NEXT, IT IS<br>APPLAUSE AMERICA.
+</BODY>
+</SAMI>
+"""

--- a/tests/test_sami.py
+++ b/tests/test_sami.py
@@ -2,8 +2,10 @@ import unittest
 
 from pycaption import SAMIReader, CaptionReadNoCaptions
 
-from .samples import SAMPLE_SAMI, SAMPLE_SAMI_EMPTY, SAMPLE_SAMI_SYNTAX_ERROR
-
+from .samples import (
+    SAMPLE_SAMI, SAMPLE_SAMI_EMPTY, SAMPLE_SAMI_SYNTAX_ERROR,
+    SAMPLE_SAMI_PARTIAL_MARGINS
+)
 
 class SAMIReaderTestCase(unittest.TestCase):
 
@@ -29,7 +31,8 @@ class SAMIReaderTestCase(unittest.TestCase):
         self.assertEquals(u"#ffeedd", p_style[u'color'])
 
     def test_6digit_color_code_from_3digit_input(self):
-        captions = SAMIReader().read(SAMPLE_SAMI.decode(u'utf-8').replace(u"#ffeedd", u"#fed"))
+        captions = SAMIReader().read(
+            SAMPLE_SAMI.decode(u'utf-8').replace(u"#ffeedd", u"#fed"))
         p_style = captions.get_style(u"p")
 
         self.assertEquals(u"#ffeedd", p_style[u'color'])
@@ -42,3 +45,12 @@ class SAMIReaderTestCase(unittest.TestCase):
     def test_invalid_markup_is_properly_handled(self):
         captions = SAMIReader().read(SAMPLE_SAMI_SYNTAX_ERROR.decode(u'utf-8'))
         self.assertEquals(2, len(captions.get_captions(u"en-US")))
+
+    def test_partial_margins(self):
+        captions = SAMIReader().read(SAMPLE_SAMI_PARTIAL_MARGINS)
+        # Ensure that undefined margins are converted to explicitly nil padding
+        # (i.e. "0%")
+        self.assertEquals(
+            captions.get_layout_info('en-US').padding.to_xml_attribute(),
+            u'0% 29pt 0% 29pt'
+        )


### PR DESCRIPTION
* Fixes issue #68 by ensuring at the level of the Padding class that all objects always have default values (0%) for empty paddings.
* Added test to ensure that SAMI files with partially defined margins
  properly convert to DFXP files with explicit padding using defaults
  for not specified SAMI values.