### PR TITLE
Fixed issue #82. Now text-align specified on spans are assigned to the Caption

### DIFF
--- a/pycaption/dfxp/base.py
+++ b/pycaption/dfxp/base.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 
 from bs4 import BeautifulSoup, NavigableString
 from xml.sax.saxutils import escape
-from copy import deepcopy
 
 from ..base import (
     BaseReader, BaseWriter, CaptionSet, Caption, CaptionNode,

--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -2,8 +2,6 @@ import sys
 import re
 from copy import deepcopy
 
-from copy import deepcopy
-
 from .base import (
     BaseReader, BaseWriter, CaptionSet, Caption, CaptionNode
 )

--- a/tests/samples/dfxp.py
+++ b/tests/samples/dfxp.py
@@ -391,6 +391,7 @@ DFXP_FROM_SAMI_WITH_POSITIONING_UNICODE = u"""\
   </styling>
   <layout>
    <region tts:padding="2pt 1pt 2pt 1pt" tts:textalign="center" xml:id="r0"></region>
+   <region tts:padding="2pt 1pt 2pt 1pt" tts:textalign="right" xml:id="r1"></region>
   </layout>
  </head>
  <body>
@@ -403,8 +404,8 @@ DFXP_FROM_SAMI_WITH_POSITIONING_UNICODE = u"""\
     When we think<br/>
     \u266a ...say bow, wow, \u266a
    </p>
-   <p begin="00:00:17.000" end="00:00:18.752" region="r0" style="p">
-    <span tts:textalign="right">we have this vision of Einstein</span>
+   <p begin="00:00:17.000" end="00:00:18.752" region="r1" style="p">
+    we have this vision of Einstein
    </p>
    <p begin="00:00:18.752" end="00:00:20.887" region="r0" style="p">
    <br/>
@@ -515,6 +516,45 @@ SAMPLE_DFXP_FROM_SAMI_WITH_LANG_MARGINS = u"""<?xml version="1.0" encoding="utf-
    <p begin="00:00:00.133" end="00:00:04.133" region="r0" style="p">
     &gt;&gt; COMING UP NEXT, IT IS<br/>
     APPLAUSE AMERICA.
+   </p>
+  </div>
+ </body>
+</tt>"""
+
+SAMPLE_DFXP_FROM_SAMI_WITH_SPAN = u"""<?xml version="1.0" encoding="utf-8"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling">
+ <head>
+  <styling>
+   <style tts:color="#ffffff" tts:fontFamily="Tahoma" tts:fontSize="24pt" tts:textAlign="center" xml:id="p"/>
+  </styling>
+  <layout>
+   <region tts:padding="20px 20px 20px 20px" tts:textAlign="center" xml:id="r0"/>
+  </layout>
+ </head>
+ <body>
+  <div region="r0" xml:lang="en-US">
+   <p begin="00:00:00.133" end="00:00:04.133" region="r0" style="p">
+    <span tts:fontSize="36pt">we have this vision of Einstein</span>
+   </p>
+  </div>
+ </body>
+</tt>"""
+
+SAMPLE_DFXP_FROM_SAMI_WITH_BAD_SPAN_ALIGN = u"""<?xml version="1.0" encoding="utf-8"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling">
+ <head>
+  <styling>
+   <style tts:color="#ffffff" tts:fontFamily="Tahoma" tts:fontSize="24pt" tts:textAlign="center" xml:id="p"/>
+  </styling>
+  <layout>
+   <region tts:padding="20px 20px 20px 20px" tts:textAlign="center" xml:id="r0"/>
+   <region tts:padding="20px 20px 20px 20px" tts:textAlign="right" xml:id="r1"/>
+  </layout>
+ </head>
+ <body>
+  <div region="r0" xml:lang="en-US">
+   <p begin="00:00:00.133" end="00:00:04.133" region="r1" style="p">
+    Some say we have this vision of Einstein as an old, wrinkly man
    </p>
   </div>
  </body>

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -299,3 +299,65 @@ SAMPLE_SAMI_LANG_MARGIN = u"""
 </BODY>
 </SAMI>
 """
+
+SAMPLE_SAMI_WITH_SPAN = u"""
+<SAMI>
+<HEAD>
+    <STYLE TYPE="Text/css">
+    <!--
+        P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
+        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+    -->
+    </STYLE>
+</HEAD>
+<BODY>
+    <SYNC start="133">
+        <P class="ENCC">
+            <SPAN Style="font-size:36pt;">we have this vision of Einstein</SPAN>
+        </P>
+    </SYNC>
+</BODY>
+</SAMI>
+"""
+
+SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN = u"""
+<SAMI>
+<HEAD>
+    <STYLE TYPE="Text/css">
+    <!--
+        P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
+        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+    -->
+    </STYLE>
+</HEAD>
+<BODY>
+    <SYNC start="133">
+        <P class="ENCC">
+            Some say <SPAN Style="text-align:right;">we have this vision of Einstein</SPAN> as an old, wrinkly man
+        </P>
+    </SYNC>
+</BODY>
+</SAMI>
+"""
+
+SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS = u"""
+<SAMI>
+<HEAD>
+    <STYLE TYPE="Text/css">
+    <!--
+        P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
+        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+    -->
+    </STYLE>
+</HEAD>
+<BODY>
+    <SYNC start="133">
+        <P class="ENCC">
+            <SPAN Style="text-align:right">Some say </SPAN>
+            <SPAN Style="text-align:left;">we have this vision of Einstein </SPAN>
+            as an old, wrinkly man
+        </P>
+    </SYNC>
+</BODY>
+</SAMI>
+"""

--- a/tests/test_sami_conversion.py
+++ b/tests/test_sami_conversion.py
@@ -11,7 +11,10 @@ from .samples import (
     DFXP_FROM_SAMI_WITH_POSITIONING_UNICODE, SAMPLE_WEBVTT_FROM_SAMI,
     SAMPLE_SAMI_PARTIAL_MARGINS, SAMPLE_SAMI_PARTIAL_MARGINS_RELATIVIZED,
     SAMPLE_DFXP_FROM_SAMI_WITH_MARGINS, SAMPLE_SAMI_LANG_MARGIN,
-    SAMPLE_DFXP_FROM_SAMI_WITH_LANG_MARGINS
+    SAMPLE_DFXP_FROM_SAMI_WITH_LANG_MARGINS, SAMPLE_SAMI_WITH_SPAN,
+    SAMPLE_DFXP_FROM_SAMI_WITH_SPAN, SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN,
+    SAMPLE_DFXP_FROM_SAMI_WITH_BAD_SPAN_ALIGN,
+    SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS
 )
 from .mixins import SRTTestingMixIn, DFXPTestingMixIn, SAMITestingMixIn, WebVTTTestingMixIn
 
@@ -74,46 +77,18 @@ class SAMItoSRTTestCase(unittest.TestCase, SRTTestingMixIn):
 
 
 class SAMItoDFXPTestCase(unittest.TestCase, DFXPTestingMixIn):
-    """
-    SAMI to DFXP conversion has been wrong since previous versions of
-    pycaption.  SAMI spans with the CSS "text-align" property are converted
-    to a DFXP span with the tt:textAlign property. This property, however, only
-    applies to <p> tags in DFXP according to the documentation. Fixing this
-    will require a considerable amount of refactoring.
 
-    See more: http://www.w3.org/TR/ttaf1-dfxp/#style-attribute-textAlign
-    """
-    @unittest.skip("To be fixed.")
-    def test_sami_to_dfxp_conversion(self):
-        caption_set = SAMIReader().read(SAMPLE_SAMI_UTF8.decode(u'utf-8'))
-        results = DFXPWriter().write(caption_set)
-        self.assertTrue(isinstance(results, unicode))
-        self.assertDFXPEquals(
-            DFXP_FROM_SAMI_WITH_POSITIONING.decode(u'utf-8'),
-            results
-        )
-
-    @unittest.skip("To be fixed.")
-    def test_sami_to_dfxp_utf8_conversion(self):
-        caption_set = SAMIReader().read(SAMPLE_SAMI_UTF8.decode(u'utf-8'))
-        results = DFXPWriter().write(caption_set)
-        self.assertTrue(isinstance(results, unicode))
-        self.assertDFXPEquals(
-            DFXP_FROM_SAMI_WITH_POSITIONING_UTF8,
-            results
-        )
-
-    @unittest.skip("To be fixed.")
     def test_sami_to_dfxp_unicode_conversion(self):
         caption_set = SAMIReader().read(SAMPLE_SAMI_UNICODE)
-        results = DFXPWriter().write(caption_set)
+        results = DFXPWriter(relativize=False,
+                             fit_to_screen=False).write(caption_set)
         self.assertTrue(isinstance(results, unicode))
         self.assertDFXPEquals(
             DFXP_FROM_SAMI_WITH_POSITIONING_UNICODE,
             results
         )
 
-    def test_sami_to_dfxp_with_margin_conversion(self):
+    def test_sami_to_dfxp_with_margin(self):
         caption_set = SAMIReader().read(SAMPLE_SAMI_PARTIAL_MARGINS)
         results = DFXPWriter(
             relativize=False, fit_to_screen=False).write(caption_set)
@@ -122,12 +97,39 @@ class SAMItoDFXPTestCase(unittest.TestCase, DFXPTestingMixIn):
             results
         )
 
-    def test_sami_to_dfxp_with_margin_for_language_conversion(self):
+    def test_sami_to_dfxp_with_margin_for_language(self):
         caption_set = SAMIReader().read(SAMPLE_SAMI_LANG_MARGIN)
         results = DFXPWriter(
             relativize=False, fit_to_screen=False).write(caption_set)
         self.assertDFXPEquals(
             SAMPLE_DFXP_FROM_SAMI_WITH_LANG_MARGINS,
+            results
+        )
+
+    def test_sami_to_dfxp_with_span(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_SPAN)
+        results = DFXPWriter(
+            relativize=False, fit_to_screen=False).write(caption_set)
+        self.assertDFXPEquals(
+            SAMPLE_DFXP_FROM_SAMI_WITH_SPAN,
+            results
+        )
+
+    def test_sami_to_dfxp_with_bad_span_align(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN)
+        results = DFXPWriter(
+            relativize=False, fit_to_screen=False).write(caption_set)
+        self.assertDFXPEquals(
+            SAMPLE_DFXP_FROM_SAMI_WITH_BAD_SPAN_ALIGN,
+            results
+        )
+
+    def test_sami_to_dfxp_ignores_multiple_span_aligns(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS)
+        results = DFXPWriter(
+            relativize=False, fit_to_screen=False).write(caption_set)
+        self.assertDFXPEquals(
+            SAMPLE_DFXP_FROM_SAMI_WITH_BAD_SPAN_ALIGN,
             results
         )
 


### PR DESCRIPTION
and not to the Node. If there are aligns specified for multiple
spans, only the first is considered.