### PR TITLE
Fixed #94.

### DIFF
--- a/pycaption/sami.py
+++ b/pycaption/sami.py
@@ -202,6 +202,11 @@ class SAMIReader(BaseReader):
                     inherit_from=layout_info
                 )
                 caption = Caption(layout_info=caption_layout)
+                for node in self.line:
+                    node.layout_info = Layout(
+                        alignment=self.first_span_alignment,
+                        inherit_from=node.layout_info
+                    )
                 self.first_span_alignment = None
 
                 caption.start = start
@@ -243,7 +248,7 @@ class SAMIReader(BaseReader):
             )
             # recursively call function for any children elements
             for a in tag.contents:
-                self._translate_tag(a)
+                self._translate_tag(a, inherit_from)
             self.line.append(
                 CaptionNode.create_style(False, {u'italics': True}))
         elif tag.name == u'span':
@@ -272,7 +277,7 @@ class SAMIReader(BaseReader):
             self.line.append(node)
         else:
             for a in tag.contents:
-                self._translate_tag(a)
+                self._translate_tag(a, inherit_from)
 
     def _translate_attrs(self, tag):
         attrs = {}

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -233,6 +233,26 @@ SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN = u"""
 </SAMI>
 """
 
+SAMPLE_SAMI_WITH_BAD_DIV_ALIGN = u"""
+<SAMI>
+<HEAD>
+    <STYLE TYPE="Text/css">
+    <!--
+        P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
+        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+    -->
+    </STYLE>
+</HEAD>
+<BODY>
+    <SYNC start="133">
+        <P class="ENCC">
+            Some say <DIV Style="text-align:right;">we have this vision of Einstein</DIV> as an old, wrinkly man
+        </P>
+    </SYNC>
+</BODY>
+</SAMI>
+"""
+
 SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS = u"""
 <SAMI>
 <HEAD>

--- a/tests/samples/webvtt.py
+++ b/tests/samples/webvtt.py
@@ -196,3 +196,11 @@ WEBVTT
 aa
 bb
 """
+
+SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN = u"""WEBVTT
+
+00:00.133 --> 00:04.133 align:right
+Some say we have this vision of Einstein as an old, wrinkly man
+"""
+
+SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN = SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN

--- a/tests/test_sami_conversion.py
+++ b/tests/test_sami_conversion.py
@@ -13,10 +13,13 @@ from .samples.sami import (
     SAMPLE_SAMI_PARTIAL_MARGINS_RELATIVIZED, SAMPLE_SAMI_LANG_MARGIN,
     SAMPLE_SAMI_WITH_SPAN, SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN,
     SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS, SAMPLE_SAMI_NO_LANG,
-    SAMPLE_SAMI_WITH_LANG
+    SAMPLE_SAMI_WITH_LANG, SAMPLE_SAMI_WITH_BAD_DIV_ALIGN
 )
 from .samples.srt import SAMPLE_SRT
-from .samples.webvtt import SAMPLE_WEBVTT_FROM_SAMI
+from .samples.webvtt import (
+    SAMPLE_WEBVTT_FROM_SAMI, SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN,
+    SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN
+)
 
 from .mixins import SRTTestingMixIn, DFXPTestingMixIn, SAMITestingMixIn, WebVTTTestingMixIn
 
@@ -127,6 +130,24 @@ class SAMItoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
             video_width=640, video_height=360).write(caption_set)
         self.assertTrue(isinstance(results, unicode))
         self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_SAMI, results)
+
+    def test_sami_to_webvtt_with_bad_span_align(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN)
+        results = WebVTTWriter(
+            video_width=640, video_height=360).write(caption_set)
+        self.assertWebVTTEquals(
+            SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN,
+            results
+        )
+
+    def test_sami_to_webvtt_with_bad_div_align(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_DIV_ALIGN)
+        results = WebVTTWriter(
+            video_width=640, video_height=360).write(caption_set)
+        self.assertWebVTTEquals(
+            SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN,
+            results
+        )
 
 
 class SAMIWithMissingLanguage(unittest.TestCase, SAMITestingMixIn):


### PR DESCRIPTION
Now weird SAMI alignment, defined in <span>, <div> etc instead of in the root element which corresponds to the caption, are preserved and applied to WebVTT cues.