### PR TITLE
Fixed #96

### DIFF
--- a/tests/samples/__init__.py
+++ b/tests/samples/__init__.py
@@ -1,5 +1,0 @@
-from .dfxp import *
-from .sami import *
-from .scc import *
-from .srt import *
-from .webvtt import *

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -253,6 +253,46 @@ SAMPLE_SAMI_WITH_BAD_DIV_ALIGN = u"""
 </SAMI>
 """
 
+SAMPLE_SAMI_WITH_P_ALIGN = u"""
+<SAMI>
+<HEAD>
+    <STYLE TYPE="Text/css">
+    <!--
+        P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
+        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+    -->
+    </STYLE>
+</HEAD>
+<BODY>
+    <SYNC start="133">
+        <P class="ENCC" Style="text-align:right;">
+            Some say we have this vision of Einstein as an old, wrinkly man
+        </P>
+    </SYNC>
+</BODY>
+</SAMI>
+"""
+
+SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN = u"""
+<SAMI>
+<HEAD>
+    <STYLE TYPE="Text/css">
+    <!--
+        P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
+        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+    -->
+    </STYLE>
+</HEAD>
+<BODY>
+    <SYNC start="133">
+        <P class="ENCC" Style="text-align:right;">
+            <SPAN Style="text-align:left;">Some say we have this vision of Einstein as an old, wrinkly man</SPAN>
+        </P>
+    </SYNC>
+</BODY>
+</SAMI>
+"""
+
 SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS = u"""
 <SAMI>
 <HEAD>

--- a/tests/samples/webvtt.py
+++ b/tests/samples/webvtt.py
@@ -204,3 +204,11 @@ Some say we have this vision of Einstein as an old, wrinkly man
 """
 
 SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN = SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN
+
+SAMPLE_WEBVTT_FROM_SAMI_WITH_P_ALIGN = u"""WEBVTT
+
+00:00.133 --> 00:04.133 align:right
+Some say we have this vision of Einstein as an old, wrinkly man
+"""
+
+SAMPLE_WEBVTT_FROM_SAMI_WITH_P_AND_SPAN_ALIGN = SAMPLE_WEBVTT_FROM_SAMI_WITH_P_ALIGN

--- a/tests/samples/webvtt.py
+++ b/tests/samples/webvtt.py
@@ -196,19 +196,3 @@ WEBVTT
 aa
 bb
 """
-
-SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN = u"""WEBVTT
-
-00:00.133 --> 00:04.133 align:right
-Some say we have this vision of Einstein as an old, wrinkly man
-"""
-
-SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN = SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN
-
-SAMPLE_WEBVTT_FROM_SAMI_WITH_P_ALIGN = u"""WEBVTT
-
-00:00.133 --> 00:04.133 align:right
-Some say we have this vision of Einstein as an old, wrinkly man
-"""
-
-SAMPLE_WEBVTT_FROM_SAMI_WITH_P_AND_SPAN_ALIGN = SAMPLE_WEBVTT_FROM_SAMI_WITH_P_ALIGN

--- a/tests/test_sami.py
+++ b/tests/test_sami.py
@@ -4,7 +4,9 @@ from pycaption import SAMIReader, CaptionReadNoCaptions
 
 from .samples.sami import (
     SAMPLE_SAMI, SAMPLE_SAMI_EMPTY, SAMPLE_SAMI_SYNTAX_ERROR,
-    SAMPLE_SAMI_PARTIAL_MARGINS
+    SAMPLE_SAMI_PARTIAL_MARGINS, SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN,
+    SAMPLE_SAMI_WITH_BAD_DIV_ALIGN, SAMPLE_SAMI_WITH_P_ALIGN,
+    SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN
 )
 
 class SAMIReaderTestCase(unittest.TestCase):
@@ -54,3 +56,25 @@ class SAMIReaderTestCase(unittest.TestCase):
             caption_set.layout_info.padding.to_xml_attribute(),
             u'0% 29pt 0% 29pt'
         )
+
+    def test_sami_with_bad_span_align(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN)
+        caption = caption_set.get_captions('en-US')[0]
+        self.assertEquals(caption.layout_info.alignment.horizontal, u'right')
+
+    def test_sami_with_bad_div_align(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_DIV_ALIGN)
+        caption = caption_set.get_captions('en-US')[0]
+        self.assertEquals(caption.layout_info.alignment.horizontal, u'right')
+
+    def test_sami_with_p_align(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_P_ALIGN)
+        caption = caption_set.get_captions('en-US')[0]
+        self.assertEquals(caption.layout_info.alignment.horizontal, u'right')
+
+    def test_sami_with_p_and_span_align(self):
+        """ <span> align DOES NOT override <p> align if it is specified inline.
+        """
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_DIV_ALIGN)
+        caption = caption_set.get_captions('en-US')[0]
+        self.assertEquals(caption.layout_info.alignment.horizontal, u'right')

--- a/tests/test_sami_conversion.py
+++ b/tests/test_sami_conversion.py
@@ -13,16 +13,10 @@ from .samples.sami import (
     SAMPLE_SAMI_PARTIAL_MARGINS_RELATIVIZED, SAMPLE_SAMI_LANG_MARGIN,
     SAMPLE_SAMI_WITH_SPAN, SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN,
     SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS, SAMPLE_SAMI_NO_LANG,
-    SAMPLE_SAMI_WITH_LANG, SAMPLE_SAMI_WITH_BAD_DIV_ALIGN,
-    SAMPLE_SAMI_WITH_P_ALIGN, SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN
+    SAMPLE_SAMI_WITH_LANG
 )
 from .samples.srt import SAMPLE_SRT
-from .samples.webvtt import (
-    SAMPLE_WEBVTT_FROM_SAMI, SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN,
-    SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN,
-    SAMPLE_WEBVTT_FROM_SAMI_WITH_P_ALIGN,
-    SAMPLE_WEBVTT_FROM_SAMI_WITH_P_AND_SPAN_ALIGN
-)
+from .samples.webvtt import SAMPLE_WEBVTT_FROM_SAMI
 
 from .mixins import SRTTestingMixIn, DFXPTestingMixIn, SAMITestingMixIn, WebVTTTestingMixIn
 
@@ -133,44 +127,6 @@ class SAMItoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
             video_width=640, video_height=360).write(caption_set)
         self.assertTrue(isinstance(results, unicode))
         self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_SAMI, results)
-
-    def test_sami_to_webvtt_with_bad_span_align(self):
-        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN)
-        results = WebVTTWriter(
-            video_width=640, video_height=360).write(caption_set)
-        self.assertWebVTTEquals(
-            SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN,
-            results
-        )
-
-    def test_sami_to_webvtt_with_bad_div_align(self):
-        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_DIV_ALIGN)
-        results = WebVTTWriter(
-            video_width=640, video_height=360).write(caption_set)
-        self.assertWebVTTEquals(
-            SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN,
-            results
-        )
-
-    def test_sami_to_webvtt_with_p_align(self):
-        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_P_ALIGN)
-        results = WebVTTWriter(
-            video_width=640, video_height=360).write(caption_set)
-        self.assertWebVTTEquals(
-            SAMPLE_WEBVTT_FROM_SAMI_WITH_P_ALIGN,
-            results
-        )
-
-    def test_sami_to_webvtt_p_and_span_align(self):
-        """ <span> align DOES NOT override <p> align if it is specified inline.
-        """
-        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN)
-        results = WebVTTWriter(
-            video_width=640, video_height=360).write(caption_set)
-        self.assertWebVTTEquals(
-            SAMPLE_WEBVTT_FROM_SAMI_WITH_P_AND_SPAN_ALIGN,
-            results
-        )
 
 
 class SAMIWithMissingLanguage(unittest.TestCase, SAMITestingMixIn):

--- a/tests/test_sami_conversion.py
+++ b/tests/test_sami_conversion.py
@@ -13,12 +13,15 @@ from .samples.sami import (
     SAMPLE_SAMI_PARTIAL_MARGINS_RELATIVIZED, SAMPLE_SAMI_LANG_MARGIN,
     SAMPLE_SAMI_WITH_SPAN, SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN,
     SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS, SAMPLE_SAMI_NO_LANG,
-    SAMPLE_SAMI_WITH_LANG, SAMPLE_SAMI_WITH_BAD_DIV_ALIGN
+    SAMPLE_SAMI_WITH_LANG, SAMPLE_SAMI_WITH_BAD_DIV_ALIGN,
+    SAMPLE_SAMI_WITH_P_ALIGN, SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN
 )
 from .samples.srt import SAMPLE_SRT
 from .samples.webvtt import (
     SAMPLE_WEBVTT_FROM_SAMI, SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_SPAN_ALIGN,
-    SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN
+    SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN,
+    SAMPLE_WEBVTT_FROM_SAMI_WITH_P_ALIGN,
+    SAMPLE_WEBVTT_FROM_SAMI_WITH_P_AND_SPAN_ALIGN
 )
 
 from .mixins import SRTTestingMixIn, DFXPTestingMixIn, SAMITestingMixIn, WebVTTTestingMixIn
@@ -146,6 +149,26 @@ class SAMItoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
             video_width=640, video_height=360).write(caption_set)
         self.assertWebVTTEquals(
             SAMPLE_WEBVTT_FROM_SAMI_WITH_BAD_DIV_ALIGN,
+            results
+        )
+
+    def test_sami_to_webvtt_with_p_align(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_P_ALIGN)
+        results = WebVTTWriter(
+            video_width=640, video_height=360).write(caption_set)
+        self.assertWebVTTEquals(
+            SAMPLE_WEBVTT_FROM_SAMI_WITH_P_ALIGN,
+            results
+        )
+
+    def test_sami_to_webvtt_p_and_span_align(self):
+        """ <span> align DOES NOT override <p> align if it is specified inline.
+        """
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN)
+        results = WebVTTWriter(
+            video_width=640, video_height=360).write(caption_set)
+        self.assertWebVTTEquals(
+            SAMPLE_WEBVTT_FROM_SAMI_WITH_P_AND_SPAN_ALIGN,
             results
         )
 


### PR DESCRIPTION
Now alignments defined in child elements of <p> DO NOT override <p> alignment when its defined inline, only if its defined in the global CSS.