### PR TITLE
Support for MicroDVD format

### DIFF
--- a/examples/example.microdvd
+++ b/examples/example.microdvd
@@ -1,0 +1,21 @@
+{230}{307}( clock ticking )
+{371}{433}MAN:|When we think|of E equals m c-squared,
+{433}{468}we have this vision of Einstein
+{468}{522}as an old, wrinkly man|with white hair.
+{522}{669}MAN 2:|E equals m c-squared is|not about an old Einstein.
+{669}{754}It's actually about|a young, energetic, dynamic,
+{754}{805}even a sexy Einstein.
+{841}{953}ACTOR AS EINSTEIN:|What would I see if I rode|on a beam of light?
+{1087}{1137}MAN:|Perhaps some sort
+{1137}{1197}of electrical force is emanating
+{1197}{1224}outwards from|the wire.
+{1224}{1255}What?
+{1255}{1282}MAN:|Faraday, my dear boy,
+{1282}{1317}electricity flows|through a wire,
+{1317}{1373}not sideways to it.
+{1373}{1412}You see, John?
+{1412}{1431}You see?
+{1549}{1614}MAN:|It is my great ambition|to demonstrate
+{1614}{1713}that nature is a closed system;
+{1713}{1762}that in any transformation,
+{1762}{1919}no amount of matter, no mass,|is ever lost and none is gained.

--- a/pycaption/__init__.py
+++ b/pycaption/__init__.py
@@ -1,5 +1,6 @@
 from .base import CaptionConverter, Caption, CaptionSet, CaptionNode
 from .dfxp import DFXPWriter, DFXPReader
+from .microdvd import MicroDVDReader, MicroDVDWriter
 from .sami import SAMIReader, SAMIWriter
 from .srt import SRTReader, SRTWriter
 from .scc import SCCReader, SCCWriter
@@ -17,7 +18,7 @@ __all__ = [
 ]
 
 SUPPORTED_READERS = (
-    DFXPReader, WebVTTReader, SAMIReader, SRTReader, SCCReader)
+    DFXPReader, MicroDVDReader, WebVTTReader, SAMIReader, SRTReader, SCCReader)
 
 
 def detect_format(caps):

--- a/pycaption/microdvd.py
+++ b/pycaption/microdvd.py
@@ -1,0 +1,102 @@
+from copy import deepcopy
+
+from .base import (
+    BaseReader, BaseWriter, CaptionSet, Caption, CaptionNode)
+from .exceptions import CaptionReadNoCaptions, InvalidInputError
+import re
+
+class MicroDVDReader(BaseReader):
+    def detect(self, content):
+        return re.match("{\d+}{\d+}", content) is not None
+
+    def read(self, content, lang=u'en-US'):
+        if type(content) != unicode:
+            raise InvalidInputError('The content is not a unicode string.')
+
+        caption_set = CaptionSet()
+        lines = content.splitlines()
+        start_line = 0
+        captions = []
+        fps = 25.0
+        for line in lines:
+            m = re.match(r"{(\d+)}{(\d+)}(.*)", line)
+            if not m: break
+            caption = Caption()
+            start, end, txt = m.groups()
+
+            if start == '0' and end == '0':
+                fps = float(txt)
+                continue
+
+            caption.start = self._framestomicro(int(start), fps)
+            caption.end = self._framestomicro(int(end), fps)
+
+            for line in txt.split('|'):
+                # skip extra blank lines
+                if not caption.nodes or line != u'':
+                    caption.nodes.append(CaptionNode.create_text(line))
+                    caption.nodes.append(CaptionNode.create_break())
+
+            # remove last line break from end of caption list
+            if len(caption.nodes):
+                caption.nodes.pop()
+                captions.append(caption)
+
+        caption_set.set_captions(lang, captions)
+
+        if caption_set.is_empty():
+            raise CaptionReadNoCaptions(u"empty caption file")
+
+        return caption_set
+
+    def _framestomicro(self, framenum, fps=25.0):
+        return int(framenum / fps * (10**6))
+
+
+class MicroDVDWriter(BaseWriter):
+    def write(self, caption_set):
+        caption_set = deepcopy(caption_set)
+
+        captions = []
+
+        for lang in caption_set.get_languages():
+            captions.append(
+                self._recreate_lang(caption_set.get_captions(lang))
+            )
+
+        return ''.join(captions)
+
+    def _microtoframes(self, micro, fps=25.0):
+        return int(micro * fps / (10**6))
+
+    def _recreate_lang(self, captions):
+        sub = u''
+        count = 1
+        for caption in captions:
+            start = self._microtoframes(caption.start)
+            end = self._microtoframes(caption.end)
+            sub += u'{%s}{%s}' % (start, end)
+
+            new_content = u''
+            for node in caption.nodes:
+                new_content = self._recreate_line(new_content, node)
+
+            # Eliminate excessive line breaks
+            new_content = new_content.strip() + '\n'
+            while u'\n\n' in new_content:
+                new_content = new_content.replace(u'\n\n', u'\n')
+            # Break unnecessary on last line
+            while u'|\n' in new_content:
+                new_content = new_content.replace(u'|\n', u'\n')
+
+            sub += new_content
+
+        return sub
+
+    def _recreate_line(self, sub, line):
+        if line.type_ == CaptionNode.TEXT:
+            return sub + u'%s' % line.content
+        elif line.type_ == CaptionNode.BREAK:
+            return sub + u'|'
+        else:
+            return sub

--- a/tests/samples/microdvd.py
+++ b/tests/samples/microdvd.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+SAMPLE_MICRODVD = u"""{230}{307}( clock ticking )
+{371}{433}MAN:|When we think|of E equals m c-squared,
+{433}{468}we have this vision of Einstein
+{468}{522}as an old, wrinkly man|with white hair.
+{522}{669}MAN 2:|E equals m c-squared is|not about an old Einstein.
+{669}{754}It's actually about|a young, energetic, dynamic,
+{754}{805}even a sexy Einstein.
+{841}{953}ACTOR AS EINSTEIN:|What would I see if I rode|on a beam of light?
+{1087}{1137}MAN:|Perhaps some sort
+{1137}{1197}of electrical force is emanating
+{1197}{1224}outwards from|the wire.
+{1224}{1255}What?
+"""
+
+SAMPLE_MICRODVD_EMPTY = u"""
+"""

--- a/tests/test_microdvd.py
+++ b/tests/test_microdvd.py
@@ -1,0 +1,31 @@
+import unittest
+
+from pycaption import MicroDVDReader, CaptionReadNoCaptions
+
+from .samples.microdvd import SAMPLE_MICRODVD, SAMPLE_MICRODVD_EMPTY
+
+
+class MicroDVDReaderTestCase(unittest.TestCase):
+
+    def test_detection(self):
+        self.assertTrue(MicroDVDReader().detect(SAMPLE_MICRODVD))
+
+    def test_caption_length(self):
+        captions = MicroDVDReader().read(SAMPLE_MICRODVD)
+
+        self.assertEquals(12, len(captions.get_captions(u"en-US")))
+
+    def test_proper_timestamps(self):
+        captions = MicroDVDReader().read(SAMPLE_MICRODVD)
+        paragraph = captions.get_captions(u"en-US")[2]
+
+        # due to lossy nature of microsec -> frame# we check that
+        # conversion is within a second of expected value
+        # (fyi: timestamps in examples/ and test/samples/ differ)
+        self.assertTrue(abs(17350000 - paragraph.start) < 10**6)
+        self.assertTrue(abs(18752000 - paragraph.end) < 10**6)
+
+    def test_empty_file(self):
+        self.assertRaises(
+            CaptionReadNoCaptions,
+            MicroDVDReader().read, SAMPLE_MICRODVD_EMPTY)


### PR DESCRIPTION
Adds support for still somewhat popular https://en.wikipedia.org/wiki/MicroDVD format.

Still missing: control codes (colors, fonts) are not supported and are displayed as is.
