### PR TITLE
Fixes #115

### DIFF
--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -84,7 +84,7 @@ class DFXPTestingMixIn(object):
 
     def _remove_styling(self, soup):
         for style in soup(u'styling'):
-            style.extract()
+            style.clear()
 
         for paragraph in soup(u'p'):
             if u'style' in paragraph.attrs:


### PR DESCRIPTION
If only the debug would've been as easy as the fix :).
Still unclear on what extract() does to the element tree differently from previous versions, but after it's called selectors start returning empty.