### PR TITLE
Support more styles in DFXP/SAMI to WebVTT conversion

### DIFF
--- a/pycaption/base.py
+++ b/pycaption/base.py
@@ -261,7 +261,7 @@ class CaptionSet(object):
         :param selector: The selector whose rules should be returned (e.g. an
             element or class name).
         """
-        return self._styles.get(selector, [])
+        return self._styles.get(selector, {})
 
     def get_styles(self):
         return self._styles.items()

--- a/pycaption/dfxp/base.py
+++ b/pycaption/dfxp/base.py
@@ -225,7 +225,10 @@ class DFXPReader(BaseReader):
         attrs = {}
         dfxp_attrs = tag.attrs
         for arg in dfxp_attrs:
-            if arg == u"style":
+            if arg.lower() == u"style":
+                # Support multiple classes per tag
+                attrs[u'classes'] = dfxp_attrs[arg].strip().split(u' ')
+                # Save old class attribute for compatibility
                 attrs[u'class'] = dfxp_attrs[arg]
             elif arg.lower() == u"tts:fontstyle" and dfxp_attrs[arg] == u"italic":
                 attrs[u'italics'] = True
@@ -239,7 +242,7 @@ class DFXPReader(BaseReader):
                 attrs[u'font-family'] = dfxp_attrs[arg]
             elif arg.lower() == u"tts:fontsize":
                 attrs[u'font-size'] = dfxp_attrs[arg]
-            elif arg == u"tts:color":
+            elif arg.lower() == u"tts:color":
                 attrs[u'color'] = dfxp_attrs[arg]
         return attrs
 

--- a/pycaption/dfxp/base.py
+++ b/pycaption/dfxp/base.py
@@ -154,7 +154,7 @@ class DFXPReader(BaseReader):
             else:
                 raise InvalidInputError(u"Unsupported offset-time metric " + metric)
 
-            return microseconds
+            return int(microseconds)
 
     def _translate_tag(self, tag):
         # convert text

--- a/pycaption/dfxp/base.py
+++ b/pycaption/dfxp/base.py
@@ -2,6 +2,8 @@ import re
 
 from copy import deepcopy
 
+import re
+
 from bs4 import BeautifulSoup, NavigableString
 from xml.sax.saxutils import escape
 
@@ -124,17 +126,35 @@ class DFXPReader(BaseReader):
         return start, end
 
     def _translate_time(self, stamp):
-        timesplit = stamp.split(u':')
-        if u'.' not in timesplit[2]:
-            timesplit[2] = timesplit[2] + u'.000'
-        secsplit = timesplit[2].split(u'.')
-        if len(timesplit) > 3:
-            secsplit.append((int(timesplit[3]) / 30) * 100)
-        microseconds = (int(timesplit[0]) * 3600000000 +
-                        int(timesplit[1]) * 60000000 +
-                        int(secsplit[0]) * 1000000 +
-                        int(secsplit[1]) * 1000)
-        return microseconds
+        if stamp[-1].isdigit():
+            timesplit = stamp.split(u':')
+            if u'.' not in timesplit[2]:
+                timesplit[2] = timesplit[2] + u'.000'
+            secsplit = timesplit[2].split(u'.')
+            if len(timesplit) > 3:
+                secsplit.append((int(timesplit[3]) / 30) * 100)
+            microseconds = (int(timesplit[0]) * 3600000000 +
+                            int(timesplit[1]) * 60000000 +
+                            int(secsplit[0]) * 1000000 +
+                            int(secsplit[1]) * 1000)
+            return microseconds
+        else:
+            # Must be offset-time
+            m = re.search('^([0-9.]+)([a-z]+)$', stamp)
+            value = float(m.group(1))
+            metric = m.group(2)
+            if metric == u"h":
+                microseconds = value * 60 * 60 * 1000000
+            elif metric == u"m":
+                microseconds = value * 60 * 1000000
+            elif metric == u"s":
+                microseconds = value * 1000000
+            elif metric == u"ms":
+                microseconds = value * 1000
+            else:
+                raise InvalidInputError(u"Unsupported offset-time metric " + metric)
+
+            return microseconds
 
     def _translate_tag(self, tag):
         # convert text
@@ -209,6 +229,10 @@ class DFXPReader(BaseReader):
                 attrs[u'class'] = dfxp_attrs[arg]
             elif arg.lower() == u"tts:fontstyle" and dfxp_attrs[arg] == u"italic":
                 attrs[u'italics'] = True
+            elif arg.lower() == u"tts:fontweight" and dfxp_attrs[arg] == u"bold":
+                attrs[u'bold'] = True
+            elif arg.lower() == u"tts:textdecoration" and u"underline" in dfxp_attrs[arg].strip().split(u" "):
+                attrs[u'underline'] = True
             elif arg.lower() == u"tts:textalign":
                 attrs[u'text-align'] = dfxp_attrs[arg]
             elif arg.lower() == u"tts:fontfamily":

--- a/pycaption/sami.py
+++ b/pycaption/sami.py
@@ -221,6 +221,16 @@ class SAMIReader(BaseReader):
 
         return captions
 
+    def _get_style_name_from_tag(self, tag):
+        if tag == u'i':
+            return u'italics'
+        elif tag == u'b':
+            return u'bold'
+        elif tag == u'u':
+            return u'underline'
+        else:
+            raise RuntimeError("Unknown style tag")
+
     def _translate_tag(self, tag, inherit_from=None):
         """
         :param inherit_from: A Layout object extracted from an ancestor tag
@@ -242,15 +252,16 @@ class SAMIReader(BaseReader):
         elif tag.name == u'br':
             self.line.append(CaptionNode.create_break(inherit_from))
         # convert italics
-        elif tag.name == u'i':
+        elif tag.name == u'i' or tag.name == u'b' or tag.name == u'u':
+            style_name = self._get_style_name_from_tag(tag.name)
             self.line.append(
-                CaptionNode.create_style(True, {u'italics': True})
+                CaptionNode.create_style(True, {style_name: True})
             )
             # recursively call function for any children elements
             for a in tag.contents:
                 self._translate_tag(a, inherit_from)
             self.line.append(
-                CaptionNode.create_style(False, {u'italics': True}))
+                CaptionNode.create_style(False, {style_name: True}))
         elif tag.name == u'span':
             self._translate_span(tag, inherit_from)
         else:
@@ -307,6 +318,10 @@ class SAMIReader(BaseReader):
                 attrs[u'font-size'] = value.strip()
             elif css_property == u'font-style' and value.strip() == u'italic':
                 attrs[u'italics'] = True
+            elif css_property == u'text-decoration' and value.strip() == u'underline':
+                attrs[u'underline'] = True
+            elif css_property == u'font-weight' and value.strip() == u'bold':
+                attrs[u'bold'] = True
             elif css_property == u'lang':
                 attrs[u'lang'] = value.strip()
             elif css_property == u'color':

--- a/pycaption/sami.py
+++ b/pycaption/sami.py
@@ -89,6 +89,11 @@ class SAMIReader(BaseReader):
             self._get_sami_parser_class()().feed(content))
         sami_soup = self._get_xml_parser_class()(content)
         caption_set = CaptionSet()
+
+        # Convert styles from CSS to internal representation
+        for style in doc_styles.items():
+            style = (style[0], self._translate_parsed_style(style[1]))
+
         caption_set.set_styles(doc_styles)
         # Get the global layout that applies to all <p> tags
         layout_info = self._build_layout(doc_styles.get('p', {}))
@@ -251,7 +256,7 @@ class SAMIReader(BaseReader):
         # convert line breaks
         elif tag.name == u'br':
             self.line.append(CaptionNode.create_break(inherit_from))
-        # convert italics
+        # convert italics, bold, and underline
         elif tag.name == u'i' or tag.name == u'b' or tag.name == u'u':
             style_name = self._get_style_name_from_tag(tag.name)
             self.line.append(
@@ -312,24 +317,36 @@ class SAMIReader(BaseReader):
                 css_property, value = style
             else:
                 continue
-            if css_property == u'font-family':
-                attrs[u'font-family'] = value.strip()
-            elif css_property == u'font-size':
-                attrs[u'font-size'] = value.strip()
-            elif css_property == u'font-style' and value.strip() == u'italic':
-                attrs[u'italics'] = True
-            elif css_property == u'text-decoration' and value.strip() == u'underline':
-                attrs[u'underline'] = True
-            elif css_property == u'font-weight' and value.strip() == u'bold':
-                attrs[u'bold'] = True
-            elif css_property == u'lang':
-                attrs[u'lang'] = value.strip()
-            elif css_property == u'color':
-                attrs[u'color'] = value.strip()
-            elif css_property == u'text-align':
+            if css_property == u'text-align':
                 self._save_first_alignment(value.strip())
+            else:
+                self._translate_css_property(attrs, css_property, value)
 
         return attrs
+
+    def _translate_parsed_style(self, styles):
+        # Keep unknown styles by default
+        attrs = styles
+        for css_property, value in styles.items():
+            self._translate_css_property(attrs, css_property, value)
+
+        return attrs
+
+    def _translate_css_property(self, attrs, css_property, value):
+        if css_property == u'font-family':
+            attrs[u'font-family'] = value.strip()
+        elif css_property == u'font-size':
+            attrs[u'font-size'] = value.strip()
+        elif css_property == u'font-style' and value.strip() == u'italic':
+            attrs[u'italics'] = True
+        elif css_property == u'text-decoration' and value.strip() == u'underline':
+            attrs[u'underline'] = True
+        elif css_property == u'font-weight' and value.strip() == u'bold':
+            attrs[u'bold'] = True
+        elif css_property == u'lang':
+            attrs[u'lang'] = value.strip()
+        elif css_property == u'color':
+            attrs[u'color'] = value.strip()
 
     def _save_first_alignment(self, align):
         """
@@ -590,10 +607,15 @@ class SAMIWriter(BaseWriter):
         sami_style = {}
 
         for key, value in rules.items():
-            sami_style[key] = value
-
-        if u'italics' in rules:
-            sami_style[u'font-style'] = u'italic'
+            # Recreate original CSS rules from internal style
+            if key == u'italics' and value == True:
+                sami_style[u'font-style'] = u'italic'
+            elif key == u'bold' and value == True:
+                sami_style[u'font-weight'] = u'bold'
+            elif key == u'underline' and value == True:
+                sami_style[u'text-decoration'] = u'underline'
+            else:
+                sami_style[key] = value
 
         return sami_style
 
@@ -630,10 +652,6 @@ class SAMIParser(HTMLParser):
         if tag == u'div':
             tag = u'span'
 
-        if tag == u'i':
-            tag = u'span'
-            attrs = [(u'style', u'font-style:italic;')]
-
         # figure out the caption language of P tags
         if tag == u'p':
             lang = self._find_lang(attrs)
@@ -662,7 +680,7 @@ class SAMIParser(HTMLParser):
     # override the parser's handling of endtags
     def handle_endtag(self, tag):
         # treat divs as spans
-        if tag == u'div' or tag == u'i':
+        if tag == u'div':
             tag = u'span'
 
         # handle incorrectly formatted sync/p tags

--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -251,7 +251,7 @@ class WebVTTWriter(BaseWriter):
         if u'class' in caption.style:
             style_class = caption.style['class']
             style = caption_set.get_style(style_class)
-            for key, value in style.iteritems():
+            for key, value in style.items():
                 if value:
                     tags = self._tags_for_style(key)
                     cue_style_tags[0] += tags[0]

--- a/tests/samples/dfxp.py
+++ b/tests/samples/dfxp.py
@@ -48,6 +48,94 @@ SAMPLE_DFXP = """\
  </body>
 </tt>"""
 
+SAMPLE_DFXP_WITH_INLINE_STYLE = """
+<?xml version="1.0" encoding="utf-8"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml"
+    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+ <head>
+  <styling>
+   <style xml:id="p" tts:color="#ffeedd" tts:fontFamily="Arial"
+          tts:fontSize="10pt" tts:textAlign="center"/>
+  </styling>
+  <layout>
+  <region tts:displayAlign="after" tts:textAlign="center" xml:id="bottom"></region>
+  </layout>
+ </head>
+ <body>
+  <div xml:lang="en-US" region="bottom">
+   <p begin="00:00:09.209" end="00:00:12.312" region="bottom" style="p">
+    This is <span tts:fontstyle="italic">italic</span>, <span tts:fontweight="bold">bold
+    </span>, <span tts:textdecoration="overline underline">
+    underline</span>, <span tts:fontstyle="italic" tts:fontweight="bold" tts:textdecoration="underline">
+    everything together in one tag</span>, and <span tts:textdecoration="underline">
+    <span tts:fontweight="bold"><span tts:fontstyle="italic">nested</span></span></span>.
+   </p>
+  </div>
+ </body>
+</tt>
+"""
+
+SAMPLE_DFXP_WITH_DEFINED_STYLE = """
+<?xml version="1.0" encoding="utf-8"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml"
+    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+ <head>
+  <styling>
+   <style xml:id="p" tts:color="#ffeedd" tts:fontFamily="Arial"
+          tts:fontSize="10pt" tts:textAlign="center"/>
+   <style xml:id="s1" tts:fontstyle="italic"/>
+   <style xml:id="s2" tts:fontweight="bold" />
+   <style xml:id="s3" tts:textdecoration="underline" />
+  </styling>
+  <layout>
+  <region tts:displayAlign="after" tts:textAlign="center" xml:id="bottom"></region>
+  </layout>
+ </head>
+ <body>
+  <div xml:lang="en-US" region="bottom">
+   <p begin="00:00:09.209" end="00:00:12.312" region="bottom" style="p">
+    This is <span style="s1">italic</span>, <span style="s2">bold</span>, <span style="s3">
+    underline</span>, <span style="s1 s2 s3">everything together in one tag</span>, and <span style="s3">
+    <span style="s2"><span style="s1">nested</span></span></span>.
+   </p>
+  </div>
+ </body>
+</tt>
+"""
+
+SAMPLE_DFXP_WITH_INHERITED_STYLE = """
+<?xml version="1.0" encoding="utf-8"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml"
+    xmlns:tts="http://www.w3.org/ns/ttml#styling">
+ <head>
+  <styling>
+   <style xml:id="p" tts:color="#ffeedd" tts:fontFamily="Arial"
+          tts:fontSize="10pt" tts:textAlign="center"/>
+   <style xml:id="s1" tts:fontstyle="italic"/>
+   <style xml:id="s2" tts:fontweight="bold" />
+   <style xml:id="s3" tts:textdecoration="underline" />
+   <style xml:id="inherit_s3" style="s3" />
+   <style xml:id="inherit_s3_underline" style="s1" tts:textdecoration="underline" /> 
+   <style xml:id="inherit_s3_bold" style="inherit_s3_underline" tts:fontweight="bold" />
+   <style xml:id="inherit_s2" style="s2" />
+   <style xml:id="inherit_s1" style="s1" />
+  </styling>
+  <layout>
+  <region tts:displayAlign="after" tts:textAlign="center" xml:id="bottom"></region>
+  </layout>
+ </head>
+ <body>
+  <div xml:lang="en-US" region="bottom">
+   <p begin="00:00:09.209" end="00:00:12.312" region="bottom" style="p">
+    This is <span style="inherit_s1">italic</span>, <span style="inherit_s2">bold</span>, <span style="inherit_s3">
+    underline</span>, <span style="inherit_s3_bold">everything together in one tag</span>, and <span style="inherit_s3">
+    <span style="inherit_s2"><span style="inherit_s1">nested</span></span></span>.
+   </p>
+  </div>
+ </body>
+</tt>
+"""
+
 SAMPLE_DFXP_WITHOUT_REGION_AND_STYLE = """
 <?xml version="1.0" encoding="utf-8"?>
 <tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml"

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -49,6 +49,96 @@ P { margin-left:  1pt;
 </BODY></SAMI>
 """
 
+SAMPLE_SAMI_WITH_STYLE_TAGS = u"""
+<SAMI><HEAD><TITLE>NOVA3213</TITLE><STYLE TYPE="text/css">
+<!--
+P { margin-left:  1pt;
+    margin-right: 1pt;
+    margin-bottom: 2pt;
+    margin-top: 2pt;
+    text-align: center;
+    font-size: 10pt;
+    font-family: Arial;
+    font-weight: normal;
+    font-style: normal;
+    color: #ffeedd; }
+
+.ENCC {Name: English; lang: en-US; SAMI_Type: CC;}
+
+--></STYLE></HEAD><BODY>
+<SYNC start="9209"><P class="ENCC">
+    I <b>do</b> <i>not</i> want to go <u>home</u>.<br />
+    I don't like it <i><u><b>there</b></u></i>.
+</P></SYNC>
+<SYNC start="12312"><P class="ENCC">&nbsp;</P></SYNC>
+</BODY></SAMI>
+"""
+
+SAMPLE_SAMI_WITH_CSS_INLINE_STYLE = u"""
+<SAMI><HEAD><TITLE>NOVA3213</TITLE><STYLE TYPE="text/css">
+<!--
+P { margin-left:  1pt;
+    margin-right: 1pt;
+    margin-bottom: 2pt;
+    margin-top: 2pt;
+    text-align: center;
+    font-size: 10pt;
+    font-family: Arial;
+    font-weight: normal;
+    font-style: normal;
+    color: #ffeedd; }
+
+.ENCC {Name: English; lang: en-US; SAMI_Type: CC;}
+
+--></STYLE></HEAD><BODY>
+<SYNC start="9209"><P class="ENCC">
+    I <span style="font-weight: bold">do</span> <span style="font-style: italic">not</span> want to go <span style="text-decoration: underline">home</span>.<br />
+    I don't like it <span style="font-weight:bold;font-style:italic;text-decoration:underline">there</span>.
+</P></SYNC>
+<SYNC start="12312"><P class="ENCC">&nbsp;</P></SYNC>
+</BODY></SAMI>
+"""
+
+SAMPLE_SAMI_WITH_CSS_ID_STYLE = u"""
+<SAMI><HEAD><TITLE>NOVA3213</TITLE><STYLE TYPE="text/css">
+<!--
+P { margin-left:  1pt;
+    margin-right: 1pt;
+    margin-bottom: 2pt;
+    margin-top: 2pt;
+    text-align: center;
+    font-size: 10pt;
+    font-family: Arial;
+    font-weight: normal;
+    font-style: normal;
+    color: #ffeedd; }
+
+#StyleItalic { font-style: italic; }
+#StyleBold { font-weight: bold; }
+#StyleUnderline { text-decoration: underline; }
+#StyleItalicBoldUnderline { font-style: italic; font-weight: bold; text-decoration: underline; }
+
+.ENCC {Name: English; lang: en-US; SAMI_Type: CC;}
+
+--></STYLE></HEAD><BODY>
+<SYNC start="9209"><P class="ENCC" id="StyleItalic">
+    This is in italics.
+</P></SYNC>
+<SYNC start="12312"><P class="ENCC">&nbsp;</P></SYNC>
+<SYNC start="14848"><P class="ENCC" id="StyleUnderline">
+    This is underlined.
+</P></SYNC>
+<SYNC start="17000"><P class="ENCC" id="StyleBold">
+    This is bold.
+</P></SYNC>
+<SYNC start="18752"><P class="ENCC">&nbsp;</P></SYNC>
+<SYNC start="20887"><P class="ENCC" id="StyleItalicBoldUnderline">
+    This is everything together.
+</P></SYNC>
+<SYNC start="26760"><P class="ENCC">&nbsp;</P></SYNC>
+</BODY></SAMI>
+"""
+
 SAMPLE_SAMI_EMPTY = u"""
 <SAMI><HEAD><TITLE>NOVA3213</TITLE><STYLE TYPE="text/css">
 <!--

--- a/tests/samples/webvtt.py
+++ b/tests/samples/webvtt.py
@@ -69,6 +69,22 @@ SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING = u"""WEBVTT
 You might not remember us. We are a typical transparent region with centered text that has an outline.
 
 00:03.500 --> 00:05.000 align:right position:25%,start line:25% size:50%
+had <u>personality.</u>
+
+00:05.500 --> 00:07.000 align:left position:50%,start line:50% size:25%
+Hello there, children! Have you seen any visitors?
+
+00:07.500 --> 00:09.000 align:right position:25%,start line:75% size:25%
+This is
+the last cue
+"""
+
+SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING_WITHOUT_STYLE = u"""WEBVTT
+
+00:01.000 --> 00:03.000 position:25%,start line:25% size:50%
+You might not remember us. We are a typical transparent region with centered text that has an outline.
+
+00:03.500 --> 00:05.000 align:right position:25%,start line:25% size:50%
 had personality.
 
 00:05.500 --> 00:07.000 align:left position:50%,start line:50% size:25%

--- a/tests/samples/webvtt.py
+++ b/tests/samples/webvtt.py
@@ -63,13 +63,41 @@ It's all about an eternal Einstein.
 
 SAMPLE_WEBVTT_FROM_SAMI = SAMPLE_WEBVTT_FROM_DFXP
 
+SAMPLE_WEBVTT_FROM_SAMI_WITH_STYLE = u"""WEBVTT
+
+00:09.209 --> 00:12.312
+I <b>do</b> <i>not</i> want to go <u>home</u>.
+I don't like it <i><u><b>there</b></u></i>.
+"""
+
+SAMPLE_WEBVTT_FROM_SAMI_WITH_ID_STYLE = u"""WEBVTT
+
+00:09.209 --> 00:12.312
+<i>This is in italics.</i>
+
+00:14.848 --> 00:17.000
+<u>This is underlined.</u>
+
+00:17.000 --> 00:18.752
+<b>This is bold.</b>
+
+00:20.887 --> 00:26.760
+<i><b><u>This is everything together.</u></b></i>
+"""
+
+SAMPLE_WEBVTT_FROM_DFXP_WITH_STYLE = u"""WEBVTT
+
+00:09.209 --> 00:12.312
+This is <i>italic</i>, <b>bold</b>, <u>underline</u>, <i><u><b>everything together in one tag</b></u></i>, and <u><b><i>nested</i></b></u>.
+"""
+
 SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING = u"""WEBVTT
 
 00:01.000 --> 00:03.000 position:25%,start line:25% size:50%
 You might not remember us. We are a typical transparent region with centered text that has an outline.
 
 00:03.500 --> 00:05.000 align:right position:25%,start line:25% size:50%
-had <u>personality.</u>
+had personality.
 
 00:05.500 --> 00:07.000 align:left position:50%,start line:50% size:25%
 Hello there, children! Have you seen any visitors?
@@ -79,13 +107,13 @@ This is
 the last cue
 """
 
-SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING_WITHOUT_STYLE = u"""WEBVTT
+SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING_AND_STYLE = u"""WEBVTT
 
 00:01.000 --> 00:03.000 position:25%,start line:25% size:50%
 You might not remember us. We are a typical transparent region with centered text that has an outline.
 
 00:03.500 --> 00:05.000 align:right position:25%,start line:25% size:50%
-had personality.
+had <u>personality.</u>
 
 00:05.500 --> 00:07.000 align:left position:50%,start line:50% size:25%
 Hello there, children! Have you seen any visitors?

--- a/tests/test_dfxp.py
+++ b/tests/test_dfxp.py
@@ -1,7 +1,7 @@
 import unittest
 
 from pycaption import DFXPReader, CaptionReadNoCaptions
-from pycaption.exceptions import CaptionReadSyntaxError
+from pycaption.exceptions import CaptionReadSyntaxError, InvalidInputError
 
 from .samples.dfxp import (
     SAMPLE_DFXP, SAMPLE_DFXP_EMPTY, SAMPLE_DFXP_SYNTAX_ERROR)
@@ -22,6 +22,19 @@ class DFXPReaderTestCase(unittest.TestCase):
 
         self.assertEquals(17000000, paragraph.start)
         self.assertEquals(18752000, paragraph.end)
+
+    def test_offset_time(self):
+        reader = DFXPReader()
+        self.assertEquals(1, reader._translate_time(u"0.001ms"))
+        self.assertEquals(2000, reader._translate_time(u"2ms"))
+        self.assertEquals(1000000, reader._translate_time(u"1s"))
+        self.assertEquals(1234567, reader._translate_time(u"1.234567s"))
+        self.assertEquals(180000000, reader._translate_time(u"3m"))
+        self.assertEquals(14400000000, reader._translate_time(u"4h"))
+        # Tick values are not supported
+        self.assertRaises(
+	        InvalidInputError, reader._translate_time, u"2.3t"
+        )
 
     def test_empty_file(self):
         self.assertRaises(

--- a/tests/test_dfxp_conversion.py
+++ b/tests/test_dfxp_conversion.py
@@ -13,7 +13,9 @@ from pycaption.dfxp.base import (
 )
 
 from .samples.dfxp import (
-    SAMPLE_DFXP, SAMPLE_DFXP_WITHOUT_REGION_AND_STYLE, SAMPLE_DFXP_WITH_POSITIONING,
+    SAMPLE_DFXP, SAMPLE_DFXP_WITH_INLINE_STYLE, SAMPLE_DFXP_WITH_DEFINED_STYLE,
+    SAMPLE_DFXP_WITH_INHERITED_STYLE,
+    SAMPLE_DFXP_WITHOUT_REGION_AND_STYLE, SAMPLE_DFXP_WITH_POSITIONING,
     SAMPLE_DFXP_WITH_RELATIVIZED_POSITIONING, SAMPLE_DFXP_LONG_CUE,
     SAMPLE_DFXP_FROM_SAMI_WITH_MARGINS, DFXP_STYLE_REGION_ALIGN_CONFLICT,
     SAMPLE_DFXP_INVALID_BUT_SUPPORTED_POSITIONING_INPUT,
@@ -22,12 +24,14 @@ from .samples.dfxp import (
     SAMPLE_DFXP_OUTPUT, SAMPLE_DFXP_STYLE_TAG_WITH_NO_XML_ID_INPUT,
     SAMPLE_DFXP_STYLE_TAG_WITH_NO_XML_ID_OUTPUT,
     SAMPLE_DFXP_LONG_CUE_FIT_TO_SCREEN, SAMPLE_DFXP_FOR_LEGACY_WRITER_INPUT,
-SAMPLE_DFXP_FOR_LEGACY_WRITER_OUTPUT
+    SAMPLE_DFXP_FOR_LEGACY_WRITER_OUTPUT
 )
 from .samples.sami import SAMPLE_SAMI
 from .samples.srt import SAMPLE_SRT
 from .samples.webvtt import (
     SAMPLE_WEBVTT_FROM_DFXP, SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING,
+    SAMPLE_WEBVTT_FROM_DFXP_WITH_STYLE,# SAMPLE_WEBVTT_FROM_DFXP_WITH_DEFINED_STYLE
+    SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING_AND_STYLE,
     SAMPLE_WEBVTT_OUTPUT_LONG_CUE, WEBVTT_FROM_DFXP_WITH_CONFLICTING_ALIGN
 )
 
@@ -178,6 +182,24 @@ class DFXPtoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
         results = WebVTTWriter().write(caption_set)
         self.assertTrue(isinstance(results, unicode))
         self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_DFXP, results)
+        
+    def test_dfxp_with_inline_style_to_webvtt_conversion(self):
+        caption_set = DFXPReader().read(SAMPLE_DFXP_WITH_INLINE_STYLE)
+        results = WebVTTWriter().write(caption_set)
+        self.assertTrue(isinstance(results, unicode))
+        self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_DFXP_WITH_STYLE, results)
+
+    def test_dfxp_with_defined_style_to_webvtt_conversion(self):
+        caption_set = DFXPReader().read(SAMPLE_DFXP_WITH_DEFINED_STYLE)
+        results = WebVTTWriter().write(caption_set)
+        self.assertTrue(isinstance(results, unicode))
+        self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_DFXP_WITH_STYLE, results)
+
+    def test_dfxp_with_inherited_style_to_webvtt_conversion(self):
+        caption_set = DFXPReader().read(SAMPLE_DFXP_WITH_INHERITED_STYLE)
+        results = WebVTTWriter().write(caption_set)
+        self.assertTrue(isinstance(results, unicode))
+        self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_DFXP_WITH_STYLE, results)
 
     def test_dfxp_with_positioning_to_webvtt_conversion(self):
         caption_set = DFXPReader().read(
@@ -187,7 +209,7 @@ class DFXPtoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
         ).write(caption_set)
         self.assertTrue(isinstance(results, unicode))
         self.assertWebVTTEquals(
-            SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING, results)
+            SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING_AND_STYLE, results)
 
     def test_dfxp_to_webvtt_adds_explicit_size(self):
         caption_set = DFXPReader().read(SAMPLE_DFXP_LONG_CUE)

--- a/tests/test_sami_conversion.py
+++ b/tests/test_sami_conversion.py
@@ -9,14 +9,18 @@ from .samples.dfxp import (
     SAMPLE_DFXP_FROM_SAMI_WITH_BAD_SPAN_ALIGN
 )
 from .samples.sami import (
-    SAMPLE_SAMI, SAMPLE_SAMI_SYNTAX_ERROR, SAMPLE_SAMI_PARTIAL_MARGINS,
-    SAMPLE_SAMI_PARTIAL_MARGINS_RELATIVIZED, SAMPLE_SAMI_LANG_MARGIN,
-    SAMPLE_SAMI_WITH_SPAN, SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN,
+    SAMPLE_SAMI, SAMPLE_SAMI_WITH_STYLE_TAGS, SAMPLE_SAMI_WITH_CSS_INLINE_STYLE,
+    SAMPLE_SAMI_WITH_CSS_ID_STYLE, SAMPLE_SAMI_SYNTAX_ERROR,
+    SAMPLE_SAMI_PARTIAL_MARGINS, SAMPLE_SAMI_PARTIAL_MARGINS_RELATIVIZED,
+    SAMPLE_SAMI_LANG_MARGIN, SAMPLE_SAMI_WITH_SPAN, SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN,
     SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS, SAMPLE_SAMI_NO_LANG,
     SAMPLE_SAMI_WITH_LANG
 )
 from .samples.srt import SAMPLE_SRT
-from .samples.webvtt import SAMPLE_WEBVTT_FROM_SAMI
+from .samples.webvtt import (
+    SAMPLE_WEBVTT_FROM_SAMI, SAMPLE_WEBVTT_FROM_SAMI_WITH_STYLE,
+    SAMPLE_WEBVTT_FROM_SAMI_WITH_ID_STYLE
+)
 
 from .mixins import SRTTestingMixIn, DFXPTestingMixIn, SAMITestingMixIn, WebVTTTestingMixIn
 
@@ -127,6 +131,27 @@ class SAMItoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
             video_width=640, video_height=360).write(caption_set)
         self.assertTrue(isinstance(results, unicode))
         self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_SAMI, results)
+        
+    def test_sami_with_style_tags_to_webvtt_conversion(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_STYLE_TAGS)
+        results = WebVTTWriter(
+            video_width=640, video_height=360).write(caption_set)
+        self.assertTrue(isinstance(results, unicode))
+        self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_SAMI_WITH_STYLE, results)
+        
+    def test_sami_with_css_inline_style_to_webvtt_conversion(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_CSS_INLINE_STYLE)
+        results = WebVTTWriter(
+            video_width=640, video_height=360).write(caption_set)
+        self.assertTrue(isinstance(results, unicode))
+        self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_SAMI_WITH_STYLE, results)
+
+    def test_sami_with_css_id_style_to_webvtt_conversion(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_CSS_ID_STYLE)
+        results = WebVTTWriter(
+            video_width=640, video_height=360).write(caption_set)
+        self.assertTrue(isinstance(results, unicode))
+        self.assertWebVTTEquals(SAMPLE_WEBVTT_FROM_SAMI_WITH_ID_STYLE, results)
 
 
 class SAMIWithMissingLanguage(unittest.TestCase, SAMITestingMixIn):

--- a/tests/test_webvtt_conversion.py
+++ b/tests/test_webvtt_conversion.py
@@ -8,7 +8,9 @@ from .samples.sami import SAMPLE_SAMI
 from .samples.srt import SAMPLE_SRT
 from .samples.webvtt import (
     SAMPLE_WEBVTT, SAMPLE_WEBVTT_FROM_WEBVTT,
-    SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING, SAMPLE_WEBVTT_WITH_SETTINGS_CUE
+    SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING,
+    SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING_WITHOUT_STYLE,
+    SAMPLE_WEBVTT_WITH_SETTINGS_CUE
 )
 from .mixins import (
     WebVTTTestingMixIn, DFXPTestingMixIn, SAMITestingMixIn, SRTTestingMixIn
@@ -34,8 +36,10 @@ class WebVTTtoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
         caption_set = WebVTTReader().read(
             SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING)
         results = WebVTTWriter().write(caption_set)
+	# TODO: Change this to SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING once
+	# reading WebVTT style tags is supported
         self.assertEquals(
-            SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING, results)
+            SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING_WITHOUT_STYLE, results)
 
 #     # TODO: Write a test that includes a WebVTT file with style tags
 #     # That will fail because the styles used in the cues are not tracked.

--- a/tests/test_webvtt_conversion.py
+++ b/tests/test_webvtt_conversion.py
@@ -9,7 +9,6 @@ from .samples.srt import SAMPLE_SRT
 from .samples.webvtt import (
     SAMPLE_WEBVTT, SAMPLE_WEBVTT_FROM_WEBVTT,
     SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING,
-    SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING_WITHOUT_STYLE,
     SAMPLE_WEBVTT_WITH_SETTINGS_CUE
 )
 from .mixins import (
@@ -36,10 +35,8 @@ class WebVTTtoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
         caption_set = WebVTTReader().read(
             SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING)
         results = WebVTTWriter().write(caption_set)
-	# TODO: Change this to SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING once
-	# reading WebVTT style tags is supported
         self.assertEquals(
-            SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING_WITHOUT_STYLE, results)
+            SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING, results)
 
 #     # TODO: Write a test that includes a WebVTT file with style tags
 #     # That will fail because the styles used in the cues are not tracked.


### PR DESCRIPTION
Extend the WebVTT writer with style writing support (italics, underline, bold)
Extend the DFXP and SAMI readers with style reading support for the same styles