### PR TITLE
Allow empty paragraph in DFXP caption file

### DIFF
--- a/pycaption/dfxp/base.py
+++ b/pycaption/dfxp/base.py
@@ -180,6 +180,10 @@ class DFXPReader(BaseReader):
         elif tag.name == u'span':
             # convert span
             self._translate_span(tag)
+        elif tag.name == u'p' and not tag.contents:
+            node = CaptionNode.create_text(
+                u'', layout_info=tag.layout_info)
+            self.nodes.append(node)
         else:
             # recursively call function for any children elements
             for a in tag.contents:

--- a/tests/samples/dfxp.py
+++ b/tests/samples/dfxp.py
@@ -1124,3 +1124,16 @@ DFXP_WITH_ALTERNATIVE_TIMING_FORMATS = u"""\
     </div>
 </body>
 </tt>"""
+
+
+SAMPLE_DFXP_EMPTY_PARAGRAPH = """
+<?xml version="1.0" encoding="UTF-16"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml">
+<body>
+  <div>
+    <p begin="0:00:02.07" end="0:00:05.07"></p>
+    <p begin="0:00:05.07" end="0:00:06.21">SESSION GOT OFF TO A LATE START,</p>
+  </div>
+ </body>
+</tt>
+"""

--- a/tests/test_dfxp.py
+++ b/tests/test_dfxp.py
@@ -1,11 +1,11 @@
 import unittest
 
 from pycaption import DFXPReader, CaptionReadNoCaptions
-from pycaption.exceptions import CaptionReadSyntaxError, InvalidInputError
+from pycaption.exceptions import CaptionReadSyntaxError, InvalidInputError, CaptionReadError
 
 from .samples.dfxp import (
     SAMPLE_DFXP, SAMPLE_DFXP_EMPTY, SAMPLE_DFXP_SYNTAX_ERROR,
-    DFXP_WITH_ALTERNATIVE_TIMING_FORMATS
+    DFXP_WITH_ALTERNATIVE_TIMING_FORMATS, SAMPLE_DFXP_EMPTY_PARAGRAPH
 )
 
 
@@ -110,6 +110,12 @@ class DFXPReaderTestCase(unittest.TestCase):
         self.assertEqual(caps[0].end, 3050000)
         self.assertEqual(caps[1].start, 4000000)
         self.assertEqual(caps[1].end, 5200000)
+
+    def test_empty_paragraph(self):
+        try:
+            DFXPReader().read(SAMPLE_DFXP_EMPTY_PARAGRAPH)
+        except CaptionReadError:
+            self.fail("Failing on empty paragraph")
 
 
 SAMPLE_DFXP_INVALID_POSITIONING_VALUE_TEMPLATE = u"""\


### PR DESCRIPTION
The [specification for DFXP](https://www.w3.org/TR/ttaf1-dfxp/#content-vocabulary-p) says that ```<p>``` elements should accept as children zero or more elements. This pull request fixes pycaption failing to read a DFXP file with a paragraph which has no children.