### PR TITLE
Fix WebVTT UnicodeDecodeError

### DIFF
--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -296,7 +296,7 @@ class WebVTTWriter(BaseWriter):
                 layout = caption.layout_info or self.global_layout
             cue_settings = self._cue_settings_from(layout)
             output += timespan + cue_settings + '\n'
-            output += cue_style_tags[0] + cue_text + cue_style_tags[1] + '\n'
+            output += cue_style_tags[0] + cue_text.decode('utf-8') + cue_style_tags[1] + '\n'
 
         return output
 


### PR DESCRIPTION
When converting from SCC with Unicode symbols like ♪ this error occurs:
```
File "/usr/local/lib/python2.7/dist-packages/pycaption-1.0.0-py2.7.egg/pycaption/webvtt.py", line 233, in write
    [self._write_caption(caption_set, caption) for caption in captions])
File "/usr/local/lib/python2.7/dist-packages/pycaption-1.0.0-py2.7.egg/pycaption/webvtt.py", line 299, in _write_caption
    output += cue_style_tags[0] + cue_text + cue_style_tags[1] + '\n'
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 0: ordinal not in range(128)
```
SCC example:
https://gist.github.com/dgpro/e980bc8bebc39c73b9d9b2de439cafd2