### PR TITLE
Insert spaces between words

### DIFF
--- a/pycaption/transcript.py
+++ b/pycaption/transcript.py
@@ -29,5 +29,5 @@ class TranscriptWriter(BaseWriter):
     def _strip_text(self, elements, lang_transcript):
         for el in elements:
             if el.type_ == CaptionNode.TEXT:
-                lang_transcript += el.content
+                lang_transcript += ' ' + el.content
         return lang_transcript


### PR DESCRIPTION
For example, subtitles from https://www.youtube.com/watch?v=kIADCk-i6-c' downloaded with `youtube-dl` have following lines:
```
00:00:00.000 --> 00:00:04.710 align:start position:19%
<c.colorE5E5E5>so<00:00:00.450><c> many</c><00:00:00.719><c> of</c><00:00:00.900><c> you</c><00:00:01.079><c> have</c><00:00:01.260><c> asked</c><00:00:01.860><c> that</c><00:00:01.949><c> same</c></c>

00:00:02.399 --> 00:00:07.259 align:start position:19%
question<00:00:02.639><c> over</c><00:00:03.240><c> and</c><00:00:03.570><c> over</c><00:00:03.720><c> again</c>
```
In the output of `transcriber` I see:
```
samequestion
```

This patch solves this problem.