### PR TITLE
Avoid confusing newline with not empty content.

### DIFF
--- a/pycaption/dfxp/base.py
+++ b/pycaption/dfxp/base.py
@@ -180,7 +180,7 @@ class DFXPReader(BaseReader):
         elif tag.name == u'span':
             # convert span
             self._translate_span(tag)
-        elif tag.name == u'p' and not tag.contents:
+        elif tag.name == u'p' and self.is_tag_content_empty(tag.contents):
             node = CaptionNode.create_text(
                 u'', layout_info=tag.layout_info)
             self.nodes.append(node)
@@ -188,6 +188,20 @@ class DFXPReader(BaseReader):
             # recursively call function for any children elements
             for a in tag.contents:
                 self._translate_tag(a)
+
+    def is_tag_content_empty(self, content_list):
+        for content in content_list:
+            # recursively check empty content for any children elements
+            if not isinstance(content, NavigableString):
+                if not self.is_tag_content_empty(content.contents):
+                    return False
+                continue
+
+            # avoid confusing newline with not empty content
+            content = content.replace('\n', '')
+            if content:
+                return False
+        return True
 
     def _translate_span(self, tag):
         # convert tag attributes

--- a/tests/samples/dfxp.py
+++ b/tests/samples/dfxp.py
@@ -1131,7 +1131,9 @@ SAMPLE_DFXP_EMPTY_PARAGRAPH = """
 <tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml">
 <body>
   <div>
-    <p begin="0:00:02.07" end="0:00:05.07"></p>
+    <p begin="0:00:02.07" end="0:00:05.07">
+    
+    </p>
     <p begin="0:00:05.07" end="0:00:06.21">SESSION GOT OFF TO A LATE START,</p>
   </div>
  </body>

--- a/tests/samples/dfxp.py
+++ b/tests/samples/dfxp.py
@@ -1131,8 +1131,35 @@ SAMPLE_DFXP_EMPTY_PARAGRAPH = """
 <tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml">
 <body>
   <div>
+    <p begin="0:00:02.07" end="0:00:05.07"></p>
+    <p begin="0:00:05.07" end="0:00:06.21">SESSION GOT OFF TO A LATE START,</p>
+  </div>
+ </body>
+</tt>
+"""
+
+SAMPLE_DFXP_EMPTY_PARAGRAPH_WITH_NEWLINE = """
+<?xml version="1.0" encoding="UTF-16"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml">
+<body>
+  <div>
+    <p begin="0:00:02.07" end="0:00:05.07">
+    </p>
+    <p begin="0:00:05.07" end="0:00:06.21">SESSION GOT OFF TO A LATE START,</p>
+  </div>
+ </body>
+</tt>
+"""
+
+SAMPLE_DFXP_EMPTY_PARAGRAPH_WITH_MULTIPLE_NEWLINES = """
+<?xml version="1.0" encoding="UTF-16"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml">
+<body>
+  <div>
     <p begin="0:00:02.07" end="0:00:05.07">
     
+
+
     </p>
     <p begin="0:00:05.07" end="0:00:06.21">SESSION GOT OFF TO A LATE START,</p>
   </div>

--- a/tests/test_dfxp.py
+++ b/tests/test_dfxp.py
@@ -5,7 +5,9 @@ from pycaption.exceptions import CaptionReadSyntaxError, InvalidInputError, Capt
 
 from .samples.dfxp import (
     SAMPLE_DFXP, SAMPLE_DFXP_EMPTY, SAMPLE_DFXP_SYNTAX_ERROR,
-    DFXP_WITH_ALTERNATIVE_TIMING_FORMATS, SAMPLE_DFXP_EMPTY_PARAGRAPH
+    DFXP_WITH_ALTERNATIVE_TIMING_FORMATS, SAMPLE_DFXP_EMPTY_PARAGRAPH,
+    SAMPLE_DFXP_EMPTY_PARAGRAPH_WITH_NEWLINE,
+    SAMPLE_DFXP_EMPTY_PARAGRAPH_WITH_MULTIPLE_NEWLINES,
 )
 
 
@@ -116,6 +118,18 @@ class DFXPReaderTestCase(unittest.TestCase):
             DFXPReader().read(SAMPLE_DFXP_EMPTY_PARAGRAPH)
         except CaptionReadError:
             self.fail("Failing on empty paragraph")
+
+    def test_empty_paragraph_with_newline(self):
+        try:
+            DFXPReader().read(SAMPLE_DFXP_EMPTY_PARAGRAPH_WITH_NEWLINE)
+        except CaptionReadError:
+            self.fail("Failing on empty paragraph with one newline")
+
+    def test_empty_paragraph_with_multiple_newlines(self):
+        try:
+            DFXPReader().read(SAMPLE_DFXP_EMPTY_PARAGRAPH_WITH_MULTIPLE_NEWLINES)
+        except CaptionReadError:
+            self.fail("Failing on empty paragraph with multiple newlines")
 
 
 SAMPLE_DFXP_INVALID_POSITIONING_VALUE_TEMPLATE = u"""\


### PR DESCRIPTION
The paragraph tag containing newlines characters only is handled as a not empty tag and end up in a  "CaptionReadError((u'Node list cannot be empty',))"  error. Handle properly empty <p> tags with newlines and modify tests to catch this kind of cases.