### PR TITLE
BUG FIX:  When reading SCC files, spaces prior to a command, like 91a…

### DIFF
--- a/pycaption/scc/specialized_collections.py
+++ b/pycaption/scc/specialized_collections.py
@@ -4,6 +4,7 @@ from ..geometry import (UnitEnum, Size, Layout, Point, Alignment,
 
 from .constants import PAC_BYTES_TO_POSITIONING_MAP, COMMANDS
 import collections
+import re
 
 
 class PreCaption(object):
@@ -509,7 +510,15 @@ class _InstructionNode(object):
     def get_text(self):
         """A little legacy code.
         """
-        return ' '.join(self.text.split())
+
+        # Save trailing whitespace, which should be preserved
+        suffix = ''
+        if self.text is not None:
+            m = re.search('\s+$', self.text)
+            if m is not None:
+                suffix = m.group(0)
+
+        return ' '.join(self.text.split()) + suffix
 
     @classmethod
     def create_break(cls, position):

--- a/tests/samples/scc.py
+++ b/tests/samples/scc.py
@@ -281,3 +281,14 @@ Scenarist_SCC V1.0
 
 00:25:00;00    942c
 """
+
+
+SAMPLE_SCC_SPACE_PRIOR_TO_ITALIC_COMMAND = """\
+Scenarist_SCC V1.0
+
+00:00:00:00     942c
+
+00:00:00:18     9420 94f2 5b43 6875 e36b 5d20 91ae c8e5 792c 2049 a76d 2043 6875 e36b ae80 942c 942f
+
+00:00:01:06     942c
+"""

--- a/tests/test_scc.py
+++ b/tests/test_scc.py
@@ -13,7 +13,8 @@ from tests.samples.scc import (
     SAMPLE_SCC_POP_ON, SAMPLE_SCC_MULTIPLE_POSITIONING,
     SAMPLE_SCC_WITH_ITALICS, SAMPLE_SCC_EMPTY, SAMPLE_SCC_ROLL_UP_RU2,
     SAMPLE_SCC_PRODUCES_BAD_LAST_END_TIME, SAMPLE_NO_POSITIONING_AT_ALL_SCC,
-    SAMPLE_SCC_NO_EXPLICIT_END_TO_LAST_CAPTION, SAMPLE_SCC_EOC_FIRST_COMMAND
+    SAMPLE_SCC_NO_EXPLICIT_END_TO_LAST_CAPTION, SAMPLE_SCC_EOC_FIRST_COMMAND,
+    SAMPLE_SCC_SPACE_PRIOR_TO_ITALIC_COMMAND
 )
 
 TOLERANCE_MICROSECONDS = 500 * 1000
@@ -153,6 +154,27 @@ class SCCReaderTestCase(unittest.TestCase):
                           caption_set.get_captions('en-US')]
 
         self.assertEqual(expected_timings, actual_timings)
+
+    def test_space_prior_to_italics_is_maintained(self):
+        caption_set = SCCReader().read(
+            SAMPLE_SCC_SPACE_PRIOR_TO_ITALIC_COMMAND
+        )
+
+        self.assertIsNotNone(caption_set)
+        self.assertIsNotNone(caption_set.get_languages())
+        self.assertEqual(1, len(caption_set.get_languages()))
+        self.assertEqual('en-US', caption_set.get_languages()[0])
+
+        captions = caption_set.get_captions('en-US')
+        self.assertIsNotNone(captions)
+        self.assertEqual(1, len(captions))
+        self.assertIsNotNone(captions[0])
+
+        caption = captions[0]
+        self.assertIsNotNone(caption.nodes)
+        self.assertEqual(4, len(caption.nodes))
+        self.assertIsNotNone(caption.nodes[0].content)
+        self.assertEqual('[Chuck] ', caption.nodes[0].content)
 
 
 class CoverageOnlyTestCase(unittest.TestCase):


### PR DESCRIPTION
When reading SCC files, spaces after a word and prior to a command, like 91ae, are trimmed. The purpose of this change is to preserve those spaces.  A unit test has also been added to verify functionality.