### PR TITLE
pycaption/webvtt.py: Add languge param to WebVTT.write()

### DIFF
--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -206,7 +206,7 @@ class WebVTTWriter(BaseWriter):
     video_width = None
     video_height = None
 
-    def write(self, caption_set):
+    def write(self, caption_set, language=None):
         """
         :type caption_set: CaptionSet
         """
@@ -223,7 +223,10 @@ class WebVTTWriter(BaseWriter):
 
         # WebVTT's language support seems to be a bit crazy, so let's just
         # support a single one for now.
-        lang = list(caption_set.get_languages())[0]
+        if language is None:
+            lang = list(caption_set.get_languages())[0]
+        else:
+            lang = language
 
         self.global_layout = caption_set.get_layout_info(lang)
 

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -424,3 +424,17 @@ SAMPLE_SAMI_WITH_LANG = """
 </body>
 </sami>
 """
+
+SAMPLE_SAMI_WITH_MULTI_LANG = """
+<sami>
+<head>
+<style type="text/css"><!--.en-US {lang: en-US;} .de-DE {lang: de-DE;}--></style>
+</head>
+<body>
+<sync start="14848">
+    <p class="en-US">Butterfly.</p>
+    <p class="de-DE">Schmetterling.</p>
+</sync>
+</body>
+</sami>
+"""

--- a/tests/samples/webvtt.py
+++ b/tests/samples/webvtt.py
@@ -245,3 +245,15 @@ SAMPLE_WEBVTT_LAST_CUE_ZERO_START = """WEBVTT
 
 00:00.000 --> 00:12.312
 ( clock ticking )"""
+
+SAMPLE_WEBVTT_MULTI_LANG_EN = """WEBVTT
+
+00:14.848 --> 00:18.848
+Butterfly.
+"""
+
+SAMPLE_WEBVTT_MULTI_LANG_DE = """WEBVTT
+
+00:14.848 --> 00:18.848
+Schmetterling.
+"""

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -6,11 +6,12 @@ from pycaption import (
 )
 
 from tests.samples.dfxp import DFXP_STYLE_REGION_ALIGN_CONFLICT
-from tests.samples.sami import SAMPLE_SAMI_DOUBLE_BR
+from tests.samples.sami import SAMPLE_SAMI_DOUBLE_BR, SAMPLE_SAMI_WITH_MULTI_LANG
 from tests.samples.srt import SAMPLE_SRT
 from tests.samples.webvtt import (
     SAMPLE_WEBVTT, SAMPLE_WEBVTT_2, SAMPLE_WEBVTT_EMPTY, SAMPLE_WEBVTT_DOUBLE_BR,
-    WEBVTT_FROM_DFXP_WITH_CONFLICTING_ALIGN, SAMPLE_WEBVTT_LAST_CUE_ZERO_START
+    WEBVTT_FROM_DFXP_WITH_CONFLICTING_ALIGN, SAMPLE_WEBVTT_LAST_CUE_ZERO_START,
+    SAMPLE_WEBVTT_MULTI_LANG_DE, SAMPLE_WEBVTT_MULTI_LANG_EN
 )
 
 
@@ -173,3 +174,10 @@ class WebVTTWriterTestCase(unittest.TestCase):
         caption_set = DFXPReader().read(DFXP_STYLE_REGION_ALIGN_CONFLICT)
         results = WebVTTWriter().write(caption_set)
         self.assertEqual(WEBVTT_FROM_DFXP_WITH_CONFLICTING_ALIGN, results)
+
+    def test_lang_option(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_MULTI_LANG)
+        results = WebVTTWriter().write(caption_set,'de-DE')
+        self.assertEqual(SAMPLE_WEBVTT_MULTI_LANG_DE, results)
+        results = WebVTTWriter().write(caption_set,'en-US')
+        self.assertEqual(SAMPLE_WEBVTT_MULTI_LANG_EN, results)


### PR DESCRIPTION
If a CaptionSet has multiple language the vtt write should be able to select between the
the languages. This param allows the language selection.