### PR TITLE
Added UTF-8 decode

### DIFF
--- a/pycaption/srt.py
+++ b/pycaption/srt.py
@@ -118,6 +118,7 @@ class SRTWriter(BaseWriter):
             while '\n\n' in new_content:
                 new_content = new_content.replace('\n\n', '\n')
 
+            new_content = new_content.decode('utf-8', 'ignore')
             srt += "%s%s" % (new_content, '\n\n')
             count += 1
 


### PR DESCRIPTION
Added the decoding of "new_content" with an "ignore" flag so that if there are invalid characters, or characters outside the ASCII 128 range that are UTF-8 encoded, they can still be decoded and written. An example is the "¿" character.