### PR TITLE
Only install enum34 when necessary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ dependencies = [
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',
-    'enum34',
+    'enum34;python_version<"3.4"',
     'six>=1.9.0'
 ]
 


### PR DESCRIPTION
- enum34 can now introduce issues when installed on Python >= 3.6
  - See https://stackoverflow.com/a/45716067/6014829
- Only install enum34 on python < 3.4