### PR TITLE
Update beautifulsoup4 version, add python 3.6 to tox testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README_PATH = os.path.join(
     'README.rst')
 
 dependencies = [
-    'beautifulsoup4>=4.2.1,<4.5.0',
+    'beautifulsoup4>=4.6.0',
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py34, py35
+envlist = py34, py35, py36
 [testenv]
 deps=
-    beautifulsoup4==4.4
+    beautifulsoup4==4.6.0
     lxml==3.6.1
     cssutils==1.0.1
 commands=python setup.py test


### PR DESCRIPTION
This will resolve a dependency problem on Ubuntu with older versions of beautifulsoup4:  

```
class TreeBuilderForHtml5lib(html5lib.treebuilders._base.TreeBuilder):
AttributeError: 'module' object has no attribute '_base'
```