### PR TITLE
Handle index error

### DIFF
--- a/pycaption/dfxp/base.py
+++ b/pycaption/dfxp/base.py
@@ -129,8 +129,13 @@ class DFXPReader(BaseReader):
     def _translate_time(self, stamp):
         if stamp[-1].isdigit():
             timesplit = stamp.split(u':')
-            if u'.' not in timesplit[2]:
-                timesplit[2] = timesplit[2] + u'.000'
+            try:
+                if u'.' not in timesplit[2]:
+                    timesplit[2] = timesplit[2] + u'.000'
+            except IndexError:
+                raise CaptionReadSyntaxError('Begin and end time should follow the '
+                                             'hour:minute:seconds.milliseconds format. Milliseconds are optional.'
+                                             'Please correct the following time {}'.format(stamp))
             secsplit = timesplit[2].split(u'.')
             if len(timesplit) > 3:
                 secsplit.append((int(timesplit[3]) / 30) * 100)

--- a/tests/samples/dfxp.py
+++ b/tests/samples/dfxp.py
@@ -292,7 +292,7 @@ SAMPLE_DFXP_EMPTY = """
 
 
 SAMPLE_DFXP_SYNTAX_ERROR = """
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-16"?>
 <tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml">
 <body>
   <div>

--- a/tests/samples/dfxp.py
+++ b/tests/samples/dfxp.py
@@ -292,12 +292,23 @@ SAMPLE_DFXP_EMPTY = """
 
 
 SAMPLE_DFXP_SYNTAX_ERROR = """
-<?xml version="1.0" encoding="UTF-16"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml">
 <body>
   <div>
     <p begin="0:00:02.07" end="0:00:05.07">>>THE GENERAL ASSEMBLY'S 2014</p>
     <p begin="0:00:05.07" end="0:00:06.21">SESSION GOT OFF TO A LATE START,</p>
+  </div>
+ </body>
+</tt>
+"""
+
+SAMPLE_DFXP_INCORRECT_TIME_FORMAT = """
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml">
+<body>
+  <div>
+    <p begin="0:00:02.07" end="0:05">Hey! Check out this error!</p>
   </div>
  </body>
 </tt>

--- a/tests/test_dfxp.py
+++ b/tests/test_dfxp.py
@@ -8,6 +8,7 @@ from .samples.dfxp import (
     DFXP_WITH_ALTERNATIVE_TIMING_FORMATS, SAMPLE_DFXP_EMPTY_PARAGRAPH,
     SAMPLE_DFXP_EMPTY_PARAGRAPH_WITH_NEWLINE,
     SAMPLE_DFXP_EMPTY_PARAGRAPH_WITH_MULTIPLE_NEWLINES,
+    SAMPLE_DFXP_INCORRECT_TIME_FORMAT,
 )
 
 
@@ -23,9 +24,13 @@ class DFXPReaderTestCase(unittest.TestCase):
     def test_proper_timestamps(self):
         captions = DFXPReader().read(SAMPLE_DFXP)
         paragraph = captions.get_captions(u"en-US")[2]
-
         self.assertEquals(17000000, paragraph.start)
         self.assertEquals(18752000, paragraph.end)
+
+    def test_incorrect_time_format(self):
+        self.assertRaises(CaptionReadSyntaxError,
+                          DFXPReader().read,
+                          SAMPLE_DFXP_INCORRECT_TIME_FORMAT)
 
     def test_offset_time(self):
         reader = DFXPReader()


### PR DESCRIPTION
We have registered cases where the begin/end time were incorrect/incomplete (e.g \<p begin="00:00:32" end="00:1"\>). This led to an index error which was not handled by pycaption in the translate_time method which assumed that timesplit[2] exists. Adding a default :00 for the seconds assumes that the time should be 00:01:00 but we can't be sure of this and it can lead to caption overlapping. For now, the best solution would be to handle the error.