### PR TITLE
Empty vtt cue is valid

### DIFF
--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -93,15 +93,10 @@ class WebVTTReader(BaseReader):
 
             elif '' == line:
                 if found_timing:
-                    if not nodes:
-                        raise CaptionReadSyntaxError(
-                            'Cue without content. (line %d)' % timing_line)
-                    else:
-                        found_timing = False
-                        caption = Caption(
-                            start, end, nodes, layout_info=layout_info)
-                        captions.append(caption)
-                        nodes = []
+                    found_timing = False
+                    caption = Caption(start, end, nodes, layout_info=layout_info)
+                    captions.append(caption)
+                    nodes = []
             else:
                 if found_timing:
                     if nodes:

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -127,16 +127,6 @@ class WebVTTReaderTestCase(unittest.TestCase):
 
     def test_invalid_files(self):
         self.assertRaises(
-            CaptionReadSyntaxError,
-            WebVTTReader().read,
-            ("\nNOTE Cues without text are invalid.\n"
-                "00:00:20.000 --> 00:00:30.000\n"
-                "\n"
-                "00:00:40.000 --> 00:00:50.000\n"
-                "foo bar baz\n")
-        )
-
-        self.assertRaises(
             CaptionReadError,
             WebVTTReader(ignore_timing_errors=False).read,
             ("00:00:20.000 --> 00:00:10.000\n"


### PR DESCRIPTION
@vladiibine @arielpontes @jnorton001 @mvmocanu (sorry for amsg, wasn't clear who is the owner here)

According to vtt spec, a cue can consist of zero or more cue components https://www.w3.org/TR/webvtt1/#cue-text - so an empty cue should really not be raising an error.

addresses https://github.com/pbs/pycaption/issues/129 too