### PR TITLE
Don't depend on enum34 for Python 3.4+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ dependencies = [
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',
-    'enum34',
+    'enum34 : python_version < "3.4"',
     'six>=1.9.0'
 ]
 


### PR DESCRIPTION
It's already in the standard library so that should be preferred. The presence of the enum34 module actually breaks some other programs for me on Python 3.7.