### PR TITLE
Add TranscriptWriter to top level package exports

### DIFF
--- a/pycaption/__init__.py
+++ b/pycaption/__init__.py
@@ -4,13 +4,14 @@ from .dfxp import DFXPWriter, DFXPReader
 from .sami import SAMIReader, SAMIWriter
 from .srt import SRTReader, SRTWriter
 from .scc import SCCReader, SCCWriter
+from .transcript import TranscriptWriter
 from .webvtt import WebVTTReader, WebVTTWriter
 from .exceptions import (
     CaptionReadError, CaptionReadNoCaptions, CaptionReadSyntaxError)
 
 
 __all__ = [
-    'CaptionConverter', 'DFXPReader', 'DFXPWriter',
+    'CaptionConverter', 'TranscriptWriter', 'DFXPReader', 'DFXPWriter',
     'SAMIReader', 'SAMIWriter', 'SRTReader', 'SRTWriter',
     'SCCReader', 'SCCWriter', 'WebVTTReader', 'WebVTTWriter',
     'CaptionReadError', 'CaptionReadNoCaptions', 'CaptionReadSyntaxError',


### PR DESCRIPTION
Can `TranscriptWriter` be included in the top level package exports? Was it excluded because of the extra nltk and numpy requirements?