### PR TITLE
Fix tests breaking due to CSS rule ordering

### DIFF
--- a/pycaption/base.py
+++ b/pycaption/base.py
@@ -330,7 +330,7 @@ class CaptionSet(object):
         return self._styles.get(selector, {})
 
     def get_styles(self):
-        return sorted(self._styles.items())
+        return self._styles.items()
 
     def set_styles(self, styles):
         self._styles = styles

--- a/pycaption/sami.py
+++ b/pycaption/sami.py
@@ -45,7 +45,7 @@ import six
 import re
 from future.backports.html.parser import HTMLParseError
 
-from collections import deque
+from collections import deque, OrderedDict
 from html.entities import name2codepoint
 from html.parser import HTMLParser
 from logging import FATAL
@@ -784,7 +784,7 @@ class SAMIParser(HTMLParser):
         :rtype: dict
         """
         sheet = self.parseString(css)
-        style_sheet = {}
+        style_sheet = []
 
         for rule in sheet:
             new_style = {}
@@ -802,9 +802,9 @@ class SAMIParser(HTMLParser):
                 else:
                     new_style[prop.name] = prop.value
             if new_style:
-                style_sheet[selector] = new_style
+                style_sheet.append((selector, new_style))
 
-        return style_sheet
+        return OrderedDict(style_sheet)
 
     def _find_lang(self, attrs):
         for attr, value in attrs:

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -412,23 +412,23 @@ SAMPLE_SAMI_IGNORE_LAYOUT = u"""<sami>
  <head>
   <style type="text/css">
    <!--
-    .subttl {
-     lang: en-US;
-     name: "Subtitles";
-     margin-left: 20px;
-     margin-bottom: 20px;
-     margin-top: 20px;
-     margin-right: 20px;
-     samitype: CC;
-    }
-
     p {
-     font-size: 24pt;
-     font-weight: bold;
+     background-color: #000;
      color: #ffffff;
      font-family: Tahoma;
-     background-color: #000;
+     font-size: 24pt;
+     font-weight: bold;
      text-align: center;
+    }
+
+    .subttl {
+     lang: en-US;
+     margin-bottom: 20px;
+     margin-left: 20px;
+     margin-right: 20px;
+     margin-top: 20px;
+     name: "Subtitles";
+     samitype: CC;
     }
    -->
   </style>


### PR DESCRIPTION
The SAMI test sample had the CSS rule sets reordered compared to the source. Since there is precedence in how CSS rules are applied, those should not be reordered. I updated the sample, and also made changes to ensure the order stays the same in python 2. The sample was also updated to accommodate for the alphabetically ordered declarations.