### PR TITLE
Upgrade beautifulsoup4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@ pip-log.txt
 
 # Sphinx documentation build
 docs/_build
+
+# Virtual Enviornments
+venv*
+
+#IDE
+.vscode
+.idea

--- a/README.rst
+++ b/README.rst
@@ -3,19 +3,30 @@ py-caption
 
 |Build Status|
 
+**PLEASE SEE** `pbs/pycaption <https://github.com/pbs/pycaption>`__ **FOR OFFICIAL RELEASES.**
+
 ``pycaption`` is a caption reading/writing module. Use one of the given Readers
 to read content into a CaptionSet object, and then use one of the Writers to
 output the CaptionSet into captions of your desired format.
 
-Requires Python 2.7.
+Version 2.0.0@learningequality passes all tests with Python 2.7, 3.4, 3.5, and 3.6.
 
 For details, see the `documentation <http://pycaption.readthedocs.org>`__.
 
 Changelog
 ---------
 
-0.5.x
-^^^^^
+2.0.0@learningequality
+^^^^^^^^^^^^^^^^^^^^^^
+- Python 2 and 3 support (see branch py27@pbs)
+- Upgraded ``beautifulsoup4`` package
+
+1.0.0@pbs
+^^^^^^^^^
+- Added Python 3 support (see `pbs/pycaption <https://github.com/pbs/pycaption>`__).
+
+0.5.x@pbs
+^^^^^^^^^
 - Added positioning support
 - Created documentation
 

--- a/pycaption/dfxp/base.py
+++ b/pycaption/dfxp/base.py
@@ -7,7 +7,8 @@ import re
 
 from copy import deepcopy
 
-from bs4 import BeautifulSoup, NavigableString
+from bs4 import BeautifulSoup
+from bs4.element import PreformattedString, NavigableString
 from xml.sax.saxutils import escape
 
 from ..base import (
@@ -342,7 +343,7 @@ class DFXPWriter(BaseWriter):
 
             body.append(div)
         self.region_creator.cleanup_regions()
-        caption_content = dfxp.prettify(formatter=None)
+        caption_content = dfxp.prettify()
         return caption_content
 
     @staticmethod
@@ -416,7 +417,7 @@ class DFXPWriter(BaseWriter):
                 line = self._recreate_span(
                     line, node, dfxp, caption_set, caption, lang)
 
-        return line.rstrip()
+        return PreformattedString(line.rstrip())
 
     def _recreate_span(self, line, node, dfxp, caption_set=None, caption=None,
                        lang=None):

--- a/pycaption/dfxp/extras.py
+++ b/pycaption/dfxp/extras.py
@@ -9,6 +9,7 @@ from ..base import BaseWriter, CaptionNode, merge_concurrent_captions
 
 from xml.sax.saxutils import escape
 from bs4 import BeautifulSoup
+from bs4.element import PreformattedString
 
 LEGACY_DFXP_BASE_MARKUP = u'''
 <tt xmlns="http://www.w3.org/ns/ttml"
@@ -137,7 +138,7 @@ class LegacyDFXPWriter(BaseWriter):
 
             body.append(div)
 
-        caption_content = dfxp.prettify(formatter=None)
+        caption_content = dfxp.prettify()
         return caption_content
 
     # force the DFXP to only have one language, trying to match on "force"
@@ -201,7 +202,7 @@ class LegacyDFXPWriter(BaseWriter):
             elif node.type_ == CaptionNode.STYLE:
                 line = self._recreate_span(line, node, dfxp)
 
-        return line.rstrip()
+        return PreformattedString(line.rstrip())
 
     def _recreate_span(self, line, node, dfxp):
         if node.start:

--- a/pycaption/sami.py
+++ b/pycaption/sami.py
@@ -92,7 +92,7 @@ class SAMIReader(BaseReader):
 
         content, doc_styles, doc_langs = (
             self._get_sami_parser_class()().feed(content))
-        sami_soup = self._get_xml_parser_class()(content)
+        sami_soup = self._get_xml_parser_class()(content, 'lxml')
 
         # Get the global layout that applies to all <p> tags
         global_layout = self._build_layout(doc_styles.get('p', {}))

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_PATH = os.path.join(
     'README.rst')
 
 dependencies = [
-    'beautifulsoup4>=4.2.1,<4.5.0',
+    'beautifulsoup4>=4.6.3',
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -19,7 +19,7 @@ class WebVTTTestingMixIn(object):
         """
         first_items = self._extract_webvtt_captions(first)
         second_items = self._extract_webvtt_captions(second)
-        self.assertEquals(first_items, second_items)
+        self.assertEqual(first_items, second_items)
 
 
 class SRTTestingMixIn(object):
@@ -36,7 +36,7 @@ class SRTTestingMixIn(object):
         """
         first_items = self._extract_srt_captions(first)
         second_items = self._extract_srt_captions(second)
-        self.assertEquals(first_items, second_items)
+        self.assertEqual(first_items, second_items)
 
 
 class CaptionSetTestingMixIn(object):
@@ -60,7 +60,7 @@ class CaptionSetTestingMixIn(object):
         text_1 = [get_text_for_caption(caption) for caption in captions_1]
         text_2 = [get_text_for_caption(caption) for caption in captions_2]
 
-        self.assertEquals(text_1, text_2)
+        self.assertEqual(text_1, text_2)
 
         def close_enough(ts1, ts2):
             return abs(ts1 - ts2) < tolerance_microseconds
@@ -70,14 +70,14 @@ class CaptionSetTestingMixIn(object):
             for caption_1, caption_2 in zip(captions_1, captions_2)
             if not close_enough(caption_1.start, caption_2.start)
         ]
-        self.assertEquals(start_differences, [])
+        self.assertEqual(start_differences, [])
 
         end_differences = [
             (caption_1.end, caption_2.end)
             for caption_1, caption_2 in zip(captions_1, captions_2)
             if not close_enough(caption_1.end, caption_2.end)
         ]
-        self.assertEquals(end_differences, [])
+        self.assertEqual(end_differences, [])
 
 
 class DFXPTestingMixIn(object):
@@ -104,8 +104,8 @@ class DFXPTestingMixIn(object):
     def assertDFXPEquals(self, first, second,
                          ignore_styling=False,
                          ignore_spans=False):
-        first_soup = BeautifulSoup(first)
-        second_soup = BeautifulSoup(second)
+        first_soup = BeautifulSoup(first, 'lxml')
+        second_soup = BeautifulSoup(second, 'lxml')
 
         if ignore_styling:
             self._remove_styling(first_soup)
@@ -118,7 +118,7 @@ class DFXPTestingMixIn(object):
         self._trim_text(first_soup)
         self._trim_text(second_soup)
 
-        self.assertEquals(first_soup, second_soup)
+        self.assertEqual(first_soup, second_soup)
 
 
 class SAMITestingMixIn(object):
@@ -132,9 +132,9 @@ class SAMITestingMixIn(object):
             for caption in soup.select(u'sync'))
 
     def assertSAMIEquals(self, first, second):
-        first_soup = BeautifulSoup(first)
-        second_soup = BeautifulSoup(second)
+        first_soup = BeautifulSoup(first, 'lxml')
+        second_soup = BeautifulSoup(second, 'lxml')
 
         first_items = self._extract_sami_captions(first_soup)
         second_items = self._extract_sami_captions(second_soup)
-        self.assertEquals(first_items, second_items)
+        self.assertEqual(first_items, second_items)

--- a/tests/test_dfxp.py
+++ b/tests/test_dfxp.py
@@ -20,23 +20,23 @@ class DFXPReaderTestCase(unittest.TestCase):
 
     def test_caption_length(self):
         captions = DFXPReader().read(SAMPLE_DFXP)
-        self.assertEquals(7, len(captions.get_captions(u"en-US")))
+        self.assertEqual(7, len(captions.get_captions(u"en-US")))
 
     def test_proper_timestamps(self):
         captions = DFXPReader().read(SAMPLE_DFXP)
         paragraph = captions.get_captions(u"en-US")[2]
 
-        self.assertEquals(17000000, paragraph.start)
-        self.assertEquals(18752000, paragraph.end)
+        self.assertEqual(17000000, paragraph.start)
+        self.assertEqual(18752000, paragraph.end)
 
     def test_offset_time(self):
         reader = DFXPReader()
-        self.assertEquals(1, reader._translate_time(u"0.001ms"))
-        self.assertEquals(2000, reader._translate_time(u"2ms"))
-        self.assertEquals(1000000, reader._translate_time(u"1s"))
-        self.assertEquals(1234567, reader._translate_time(u"1.234567s"))
-        self.assertEquals(180000000, reader._translate_time(u"3m"))
-        self.assertEquals(14400000000, reader._translate_time(u"4h"))
+        self.assertEqual(1, reader._translate_time(u"0.001ms"))
+        self.assertEqual(2000, reader._translate_time(u"2ms"))
+        self.assertEqual(1000000, reader._translate_time(u"1s"))
+        self.assertEqual(1234567, reader._translate_time(u"1.234567s"))
+        self.assertEqual(180000000, reader._translate_time(u"3m"))
+        self.assertEqual(14400000000, reader._translate_time(u"4h"))
         # Tick values are not supported
         self.assertRaises(
 	        InvalidInputError, reader._translate_time, u"2.3t"
@@ -49,7 +49,7 @@ class DFXPReaderTestCase(unittest.TestCase):
 
     def test_invalid_markup_is_properly_handled(self):
         captions = DFXPReader().read(SAMPLE_DFXP_SYNTAX_ERROR)
-        self.assertEquals(2, len(captions.get_captions(u"en-US")))
+        self.assertEqual(2, len(captions.get_captions(u"en-US")))
 
     def test_caption_error_for_invalid_positioning_values(self):
         invalid_value_dfxp = (

--- a/tests/test_dfxp_conversion.py
+++ b/tests/test_dfxp_conversion.py
@@ -66,7 +66,7 @@ class DFXPtoDFXPTestCase(unittest.TestCase, DFXPTestingMixIn):
         style = soup.find(u'style', {u'xml:id': DFXP_DEFAULT_STYLE_ID})
 
         self.assertTrue(style)
-        self.assertEquals(style.attrs, default_style)
+        self.assertEqual(style.attrs, default_style)
 
     def test_default_styling_p_tags(self):
         caption_set = DFXPReader().read(SAMPLE_DFXP)
@@ -74,7 +74,7 @@ class DFXPtoDFXPTestCase(unittest.TestCase, DFXPTestingMixIn):
 
         soup = BeautifulSoup(result, u'xml')
         for p in soup.find_all(u'p'):
-            self.assertEquals(p.attrs.get(u'style'), 'p')
+            self.assertEqual(p.attrs.get(u'style'), 'p')
 
     def test_default_region_tag(self):
         caption_set = DFXPReader().read(SAMPLE_DFXP)
@@ -87,7 +87,7 @@ class DFXPtoDFXPTestCase(unittest.TestCase, DFXPTestingMixIn):
         default_region[u'xml:id'] = DFXP_DEFAULT_REGION_ID
 
         self.assertTrue(region)
-        self.assertEquals(region.attrs[u'xml:id'], DFXP_DEFAULT_REGION_ID)
+        self.assertEqual(region.attrs[u'xml:id'], DFXP_DEFAULT_REGION_ID)
         self.assertEqual(region.attrs, default_region)
 
     def test_default_region_p_tags(self):
@@ -96,7 +96,7 @@ class DFXPtoDFXPTestCase(unittest.TestCase, DFXPTestingMixIn):
 
         soup = BeautifulSoup(result, u'xml')
         for p in soup.find_all(u'p'):
-            self.assertEquals(p.attrs.get(u'region'), DFXP_DEFAULT_REGION_ID)
+            self.assertEqual(p.attrs.get(u'region'), DFXP_DEFAULT_REGION_ID)
 
     def test_correct_region_attributes_are_recreated(self):
         caption_set = DFXPReader().read(SAMPLE_DFXP_MULTIPLE_REGIONS_INPUT)
@@ -231,7 +231,7 @@ class DFXPtoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
         caption_set = DFXPReader().read(SAMPLE_DFXP_LONG_CUE)
         results = WebVTTWriter().write(caption_set)
         self.assertTrue(isinstance(results, text_type))
-        self.assertEquals(
+        self.assertEqual(
             SAMPLE_WEBVTT_OUTPUT_LONG_CUE, results)
 
     def test_dfxp_to_webvtt_preserves_proper_alignment(self):
@@ -240,7 +240,7 @@ class DFXPtoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
         # WebVTTWriter.
         caption_set = DFXPReader().read(DFXP_STYLE_REGION_ALIGN_CONFLICT)
         results = WebVTTWriter().write(caption_set)
-        self.assertEquals(
+        self.assertEqual(
             WEBVTT_FROM_DFXP_WITH_CONFLICTING_ALIGN, results)
 
 

--- a/tests/test_dfxp_extras.py
+++ b/tests/test_dfxp_extras.py
@@ -78,7 +78,7 @@ class SinglePositioningDFXPWRiterTestCase(unittest.TestCase):
 
         dfxp = SinglePositioningDFXPWriter(new_region).write(caption_set)
 
-        region = BeautifulSoup(dfxp).find('region')
+        region = BeautifulSoup(dfxp, 'lxml').find('region')
         self.assertTrue('xml:id' in region.attrs)
         self.assertNotEqual(region.attrs['xml:id'], DFXP_DEFAULT_REGION_ID)
         self.assertEqual(len(region.attrs), 3)

--- a/tests/test_sami.py
+++ b/tests/test_sami.py
@@ -19,27 +19,27 @@ class SAMIReaderTestCase(unittest.TestCase):
     def test_caption_length(self):
         captions = SAMIReader().read(SAMPLE_SAMI)
 
-        self.assertEquals(7, len(captions.get_captions("en-US")))
+        self.assertEqual(7, len(captions.get_captions("en-US")))
 
     def test_proper_timestamps(self):
         captions = SAMIReader().read(SAMPLE_SAMI)
         paragraph = captions.get_captions("en-US")[2]
 
-        self.assertEquals(17000000, paragraph.start)
-        self.assertEquals(18752000, paragraph.end)
+        self.assertEqual(17000000, paragraph.start)
+        self.assertEqual(18752000, paragraph.end)
 
     def test_6digit_color_code_from_6digit_input(self):
         captions = SAMIReader().read(SAMPLE_SAMI)
         p_style = captions.get_style("p")
 
-        self.assertEquals("#ffeedd", p_style[u'color'])
+        self.assertEqual("#ffeedd", p_style[u'color'])
 
     def test_6digit_color_code_from_3digit_input(self):
         captions = SAMIReader().read(
             SAMPLE_SAMI.replace("#ffeedd", "#fed"))
         p_style = captions.get_style("p")
 
-        self.assertEquals("#ffeedd", p_style[u'color'])
+        self.assertEqual("#ffeedd", p_style[u'color'])
 
     def test_empty_file(self):
         self.assertRaises(
@@ -48,13 +48,13 @@ class SAMIReaderTestCase(unittest.TestCase):
 
     def test_invalid_markup_is_properly_handled(self):
         captions = SAMIReader().read(SAMPLE_SAMI_SYNTAX_ERROR)
-        self.assertEquals(2, len(captions.get_captions("en-US")))
+        self.assertEqual(2, len(captions.get_captions("en-US")))
 
     def test_partial_margins(self):
         caption_set = SAMIReader().read(SAMPLE_SAMI_PARTIAL_MARGINS)
         # Ensure that undefined margins are converted to explicitly nil padding
         # (i.e. "0%")
-        self.assertEquals(
+        self.assertEqual(
             caption_set.layout_info.padding.to_xml_attribute(),
             u'0% 29pt 0% 29pt'
         )
@@ -62,21 +62,21 @@ class SAMIReaderTestCase(unittest.TestCase):
     def test_sami_with_bad_span_align(self):
         caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN)
         caption = caption_set.get_captions('en-US')[0]
-        self.assertEquals(caption.layout_info.alignment.horizontal, HorizontalAlignmentEnum.RIGHT)
+        self.assertEqual(caption.layout_info.alignment.horizontal, HorizontalAlignmentEnum.RIGHT)
 
     def test_sami_with_bad_div_align(self):
         caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_BAD_DIV_ALIGN)
         caption = caption_set.get_captions('en-US')[0]
-        self.assertEquals(caption.layout_info.alignment.horizontal, HorizontalAlignmentEnum.RIGHT)
+        self.assertEqual(caption.layout_info.alignment.horizontal, HorizontalAlignmentEnum.RIGHT)
 
     def test_sami_with_p_align(self):
         caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_P_ALIGN)
         caption = caption_set.get_captions('en-US')[0]
-        self.assertEquals(caption.layout_info.alignment.horizontal, HorizontalAlignmentEnum.RIGHT)
+        self.assertEqual(caption.layout_info.alignment.horizontal, HorizontalAlignmentEnum.RIGHT)
 
     def test_sami_with_p_and_span_align(self):
         """ <span> align DOES NOT override <p> align if it is specified inline.
         """
         caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN)
         caption = caption_set.get_captions('en-US')[0]
-        self.assertEquals(caption.layout_info.alignment.horizontal, HorizontalAlignmentEnum.RIGHT)
+        self.assertEqual(caption.layout_info.alignment.horizontal, HorizontalAlignmentEnum.RIGHT)

--- a/tests/test_scc.py
+++ b/tests/test_scc.py
@@ -29,7 +29,7 @@ class SCCReaderTestCase(unittest.TestCase):
     def test_caption_length(self):
         captions = SCCReader().read(SAMPLE_SCC_POP_ON)
 
-        self.assertEquals(7, len(captions.get_captions(u"en-US")))
+        self.assertEqual(7, len(captions.get_captions(u"en-US")))
 
     def test_proper_timestamps(self):
         captions = SCCReader().read(SAMPLE_SCC_POP_ON)

--- a/tests/test_srt.py
+++ b/tests/test_srt.py
@@ -16,18 +16,18 @@ class SRTReaderTestCase(unittest.TestCase):
     def test_caption_length(self):
         captions = SRTReader().read(SAMPLE_SRT)
 
-        self.assertEquals(7, len(captions.get_captions(u"en-US")))
+        self.assertEqual(7, len(captions.get_captions(u"en-US")))
 
     def test_proper_timestamps(self):
         captions = SRTReader().read(SAMPLE_SRT)
         paragraph = captions.get_captions(u"en-US")[2]
 
-        self.assertEquals(17000000, paragraph.start)
-        self.assertEquals(18752000, paragraph.end)
+        self.assertEqual(17000000, paragraph.start)
+        self.assertEqual(18752000, paragraph.end)
 
     def test_numeric_captions(self):
         captions = SRTReader().read(SAMPLE_SRT_NUMERIC)
-        self.assertEquals(7, len(captions.get_captions(u"en-US")))
+        self.assertEqual(7, len(captions.get_captions(u"en-US")))
 
     def test_empty_file(self):
         self.assertRaises(
@@ -36,8 +36,8 @@ class SRTReaderTestCase(unittest.TestCase):
 
     def test_extra_empty_line(self):
         captions = SRTReader().read(SAMPLE_SRT_BLANK_LINES)
-        self.assertEquals(2, len(captions.get_captions(u"en-US")))
+        self.assertEqual(2, len(captions.get_captions(u"en-US")))
 
     def test_extra_trailing_empty_line(self):
         captions = SRTReader().read(SAMPLE_SRT_TRAILING_BLANKS)
-        self.assertEquals(2, len(captions.get_captions(u"en-US")))
+        self.assertEqual(2, len(captions.get_captions(u"en-US")))

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -147,7 +147,7 @@ class WebVTTReaderTestCase(unittest.TestCase):
     def test_zero_start(self):
         captions = self.reader.read(SAMPLE_WEBVTT_LAST_CUE_ZERO_START)
         cue = captions.get_captions(u'en-US')[0]
-        self.assertEquals(cue.start, 0)
+        self.assertEqual(cue.start, 0)
 
 
 class WebVTTWriterTestCase(unittest.TestCase):
@@ -163,5 +163,5 @@ class WebVTTWriterTestCase(unittest.TestCase):
     def test_break_node_positioning_is_ignored(self):
         caption_set = DFXPReader().read(DFXP_STYLE_REGION_ALIGN_CONFLICT)
         results = WebVTTWriter().write(caption_set)
-        self.assertEquals(
+        self.assertEqual(
             WEBVTT_FROM_DFXP_WITH_CONFLICTING_ALIGN, results)

--- a/tests/test_webvtt_conversion.py
+++ b/tests/test_webvtt_conversion.py
@@ -37,14 +37,14 @@ class WebVTTtoWebVTTTestCase(unittest.TestCase, WebVTTTestingMixIn):
         caption_set = WebVTTReader().read(
             SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING)
         results = WebVTTWriter().write(caption_set)
-        self.assertEquals(
+        self.assertEqual(
             SAMPLE_WEBVTT_FROM_DFXP_WITH_POSITIONING, results)
 
     def test_empty_cues_are_deleted(self):
         caption_set = WebVTTReader().read(
             SAMPLE_WEBVTT_EMPTY_CUE)
         results = WebVTTWriter().write(caption_set)
-        self.assertEquals(
+        self.assertEqual(
             SAMPLE_WEBVTT_FROM_EMPTY_CUE, results)
 
 #     # TODO: Write a test that includes a WebVTT file with style tags

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,9 @@
 [tox]
 envlist =
     py27
+    py34
     py35
+    py36
 [testenv]
 deps=
     beautifulsoup4


### PR DESCRIPTION
In order to upgrade `beautifulsoup4`, the following needed to happen:
1. Resolve self-closing tags like `<region />` that were not being rendered as self-closing by enabling pretty-printing.
2. Avoid side effect of fixing 1, where manually generated HTML was being entity encoded due to pretty-printing, by adding it to the document as a `PreformattedString` which prevents the encoding of it.
3. Pass parser to `beautifulsoup4` to avoid errors and warnings.

Also updated:
- Changed `assertEquals` to `assertEqual` to get rid of deprecation warnings in test output