### PR TITLE
Default language and handling

### DIFF
--- a/pycaption/base.py
+++ b/pycaption/base.py
@@ -8,7 +8,8 @@ from numbers import Number
 
 from .exceptions import CaptionReadError, CaptionReadTimingError
 
-DEFAULT_LANGUAGE_CODE = u'en-US'
+# `und` a special identifier for an undetermined language according to ISO 639-2
+DEFAULT_LANGUAGE_CODE = u'und'
 
 
 def force_byte_string(content):

--- a/pycaption/dfxp/base.py
+++ b/pycaption/dfxp/base.py
@@ -76,9 +76,11 @@ class DFXPReader(BaseReader):
         caption_dict = {}
         style_dict = {}
 
+        default_language = dfxp_document.tt.attrs.get(u'xml:lang', DEFAULT_LANGUAGE_CODE)
+
         # Each div represents all the captions for a single language.
         for div in dfxp_document.find_all(u'div'):
-            lang = div.attrs.get(u'xml:lang', DEFAULT_LANGUAGE_CODE)
+            lang = div.attrs.get(u'xml:lang', default_language)
 
             caption_dict[lang] = self._translate_div(div)
 
@@ -298,6 +300,9 @@ class DFXPWriter(BaseWriter):
         langs = caption_set.get_languages()
         if force in langs:
             langs = [force]
+            dfxp.find(u'tt')[u'xml:lang'] = six.text_type(force)
+        else:
+            dfxp.find(u'tt')[u'xml:lang'] = u"en"
 
         caption_set = deepcopy(caption_set)
 

--- a/tests/samples/dfxp.py
+++ b/tests/samples/dfxp.py
@@ -177,7 +177,7 @@ SAMPLE_DFXP_WITHOUT_REGION_AND_STYLE = """
 </tt>"""
 
 SAMPLE_DFXP_WITH_POSITIONING = """<?xml version="1.0" encoding="utf-8"?>
-<tt xml:lang="en-us"
+<tt xml:lang="en-US"
     xmlns="http://www.w3.org/ns/ttml"
     xmlns:tts='http://www.w3.org/ns/ttml#styling'
     >
@@ -390,7 +390,7 @@ SAMPLE_DFXP_LONG_CUE_FIT_TO_SCREEN = """<?xml version="1.0" encoding="utf-8"?>
   </layout>
  </head>
  <body>
-  <div region="bottom" xml:lang="en-US">
+  <div region="bottom" xml:lang="en">
    <p begin="00:00:01.000" end="00:00:02.000" region="bottom" style="basic">
     NARRATOR:
    </p>
@@ -803,7 +803,7 @@ SAMPLE_DFXP_STYLE_TAG_WITH_NO_XML_ID_INPUT = """\
   </layout>
  </head>
  <body>
-  <div xml:lang="en-US">
+  <div xml:lang="en">
    <p begin="00:00:09.209" end="00:00:12.312" region="r0" style="p">
     ( clock ticking )
    </p>
@@ -830,7 +830,7 @@ SAMPLE_DFXP_STYLE_TAG_WITH_NO_XML_ID_OUTPUT = """\
   </layout>
  </head>
  <body>
-  <div region="bottom" xml:lang="en-US">
+  <div region="bottom" xml:lang="en">
    <p begin="00:00:09.209" end="00:00:12.312" region="r0" style="p">
     ( clock ticking )
    </p>
@@ -977,7 +977,7 @@ SAMPLE_DFXP_FOR_LEGACY_WRITER_INPUT = """
   </layout>
  </head>
  <body>
-  <div xml:lang="en-US">
+  <div xml:lang="en">
    <p begin="00:00:09.209" end="00:00:12.312" style="p">
     ( clock ticking )
    </p>
@@ -1022,7 +1022,7 @@ SAMPLE_DFXP_FOR_LEGACY_WRITER_OUTPUT = """\
   </layout>
  </head>
  <body>
-  <div xml:lang="en-US">
+  <div xml:lang="en">
    <p begin="00:00:09.209" end="00:00:12.312" region="bottom" style="p">
     ( clock ticking )
    </p>
@@ -1058,7 +1058,7 @@ SAMPLE_DFXP_FOR_LEGACY_WRITER_OUTPUT = """\
 </tt>"""
 
 DFXP_WITH_CONCURRENT_CAPTIONS = u"""\
-<tt xml:lang="en-us"
+<tt xml:lang="en-US"
     xmlns="http://www.w3.org/ns/ttml"
     xmlns:tts='http://www.w3.org/ns/ttml#styling'
     >
@@ -1091,7 +1091,7 @@ DFXP_WITH_CONCURRENT_CAPTIONS = u"""\
 
 # 'style_name' is the template parameter to use in str.format
 DFXP_WITH_TEMPLATED_STYLE = """\
-<tt xml:lang="en-us"
+<tt xml:lang="en-US"
     xmlns="http://www.w3.org/ns/ttml"
     xmlns:tts='http://www.w3.org/ns/ttml#styling'
     >
@@ -1114,7 +1114,7 @@ DFXP_WITH_TEMPLATED_STYLE = """\
 """
 
 DFXP_WITH_ESCAPED_APOSTROPHE = u"""\
-<tt xml:lang="en-us"
+<tt xml:lang="en-US"
     xmlns="http://www.w3.org/ns/ttml"
     xmlns:tts='http://www.w3.org/ns/ttml#styling'
     >
@@ -1133,7 +1133,7 @@ DFXP_WITH_ESCAPED_APOSTROPHE = u"""\
 </tt>"""
 
 DFXP_WITH_ALTERNATIVE_TIMING_FORMATS = u"""\
-<tt xml:lang="en-us"
+<tt xml:lang="en-US"
     xmlns="http://www.w3.org/ns/ttml"
     xmlns:tts='http://www.w3.org/ns/ttml#styling'
     >

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -290,7 +290,7 @@ SAMPLE_SAMI_WITH_SPAN = u"""
     <STYLE TYPE="Text/css">
     <!--
         P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
-        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+        .ENCC {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
     -->
     </STYLE>
 </HEAD>
@@ -310,7 +310,7 @@ SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN = u"""
     <STYLE TYPE="Text/css">
     <!--
         P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
-        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+        .ENCC {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
     -->
     </STYLE>
 </HEAD>
@@ -330,7 +330,7 @@ SAMPLE_SAMI_WITH_BAD_DIV_ALIGN = u"""
     <STYLE TYPE="Text/css">
     <!--
         P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
-        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+        .ENCC {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
     -->
     </STYLE>
 </HEAD>
@@ -350,7 +350,7 @@ SAMPLE_SAMI_WITH_P_ALIGN = u"""
     <STYLE TYPE="Text/css">
     <!--
         P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
-        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+        .ENCC {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
     -->
     </STYLE>
 </HEAD>
@@ -370,7 +370,7 @@ SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN = u"""
     <STYLE TYPE="Text/css">
     <!--
         P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
-        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+        .ENCC {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
     -->
     </STYLE>
 </HEAD>
@@ -390,7 +390,7 @@ SAMPLE_SAMI_WITH_MULTIPLE_SPAN_ALIGNS = u"""
     <STYLE TYPE="Text/css">
     <!--
         P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
-        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+        .ENCC {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
     -->
     </STYLE>
 </HEAD>
@@ -421,7 +421,7 @@ SAMPLE_SAMI_IGNORE_LAYOUT = u"""<sami>
      text-align: center;
     }
 
-    .subttl {
+    .encc {
      lang: en-US;
      margin-bottom: 20px;
      margin-left: 20px;
@@ -435,7 +435,7 @@ SAMPLE_SAMI_IGNORE_LAYOUT = u"""<sami>
  </head>
  <body>
   <sync start="133">
-   <p class="en-US" p_style="class:encc;">
+   <p class="encc" p_style="class:encc;">
     Some say  we have this vision of Einstein  as an old, wrinkly man
    </p>
   </sync>

--- a/tests/test_dfxp.py
+++ b/tests/test_dfxp.py
@@ -49,7 +49,7 @@ class DFXPReaderTestCase(unittest.TestCase):
 
     def test_invalid_markup_is_properly_handled(self):
         captions = DFXPReader().read(SAMPLE_DFXP_SYNTAX_ERROR)
-        self.assertEquals(2, len(captions.get_captions(u"en-US")))
+        self.assertEquals(2, len(captions.get_captions(u"en")))
 
     def test_caption_error_for_invalid_positioning_values(self):
         invalid_value_dfxp = (

--- a/tests/test_sami_conversion.py
+++ b/tests/test_sami_conversion.py
@@ -165,4 +165,4 @@ class SAMIWithMissingLanguage(unittest.TestCase, SAMITestingMixIn):
         results = SAMIWriter().write(caption_set)
         self.assertTrue(isinstance(results, six.text_type))
         self.assertSAMIEquals(SAMPLE_SAMI_WITH_LANG, results)
-        self.assertTrue("lang: en-US;" in results)
+        self.assertTrue("lang: und;" in results)


### PR DESCRIPTION
## Issue
There's an issue with TTML/DFXP documents where all language information contained in the document was not being utilized. For example, [this TTML file](https://www.youtube.com/api/timedtext?lang=ar&v=C_9f7Qq4YZc&fmt=ttml&name=) doesn't have a language on the individual `<div>` tags ([reference](https://github.com/pbs/pycaption/blob/master/pycaption/dfxp/base.py#L72)) so it was defaulting to `en-US` which is incorrect. The document has `xml:lang="ar"` on the root `<tt>` element, so by default that should be used.

## Related Issue
The default language is `en-US` (`DEFAULT_LANGUAGE_CODE = 'en-US'`) which from the consumer side of `pycaption` is fairly ambiguous as it's not clear if that language was actually present or just defaulted to. According to ISO-639-2, a special code of `und` is appropriate when the language of linguistic content is undetermined ([reference](http://www.loc.gov/standards/iso639-2/faq.html#25)). 

## Fixes
- Updated DFXP reader to fallback to the document's language if no language is present on individual `<div>`
- Updated the `DEFAULT_LANGUAGE_CODE` constant to `und` and fix invalid test content that surfaced with this change