### PR TITLE
enum34 is only needed for Python < 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ dependencies = [
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',
-    'enum34',
+    'enum34;python_version<"3.4"',
     'six>=1.9.0'
 ]
 


### PR DESCRIPTION
Only require it for such versions