### PR TITLE
Include tests in PyPI tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include pycaption/english.pickle
-recursive-exclude tests *
+recursive-include tests *
 include README.rst


### PR DESCRIPTION
In OpenBSD we use the regression tests in order to make sure that updates
work properly and that an update of a dependency doesn't break a package.
Having the regression tests in the PyPI tarball makes that much easier.