### PR TITLE
Fix test failures on xmlns:= with unpin BeautifulSoup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 
 python:
     - 2.7
-    - 3.4
+    - 3.5
 
 script: python setup.py test
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ README_PATH = os.path.join(
     'README.rst')
 
 dependencies = [
-    'beautifulsoup4>=4.2.1,<4.5.0',
+    'beautifulsoup4>=4.8.1',
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',


### PR DESCRIPTION
This is causing 18 failures in recent CI dfxp conversion tests.

I did not look into which [BeautifulSoup version corrects the bug](https://bugs.launchpad.net/beautifulsoup/+bug/1849618),
4.8.1 was mentioned as working is the bug report.

Should any of the other dependencies also be unpinned?