### PR TITLE
updated beautifulsoup to >=4.8.2 to fix invalid xml generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-    - 3.4
     - 3.5
 
 script: python setup.py test

--- a/README.rst
+++ b/README.rst
@@ -1,34 +1,5 @@
-py-caption
+pycaption-od
 ==========
 
-|Build Status|
-
-``pycaption`` is a caption reading/writing module. Use one of the given Readers
-to read content into a CaptionSet object, and then use one of the Writers to
-output the CaptionSet into captions of your desired format.
-
-Tested with Python 3.4 and 3.5.
-(for Python 2 use pycaption < 1.0.0)
-
-For details, see the `documentation <http://pycaption.readthedocs.org>`__.
-
-Changelog
----------
-
-1.0.0
-^^^^^
-- Added Python 3 support
-
-0.5.x
-^^^^^
-- Added positioning support
-- Created documentation
-
-License
--------
-
-This module is Copyright 2012 PBS.org and is available under the `Apache
-License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>`__.
-
-.. |Build Status| image:: https://travis-ci.org/pbs/pycaption.png?branch=master
-   :target: https://travis-ci.org/pbs/pycaption
+``pycaption-od`` is a clone of `pycaption` with the only change being an update of the 
+beautifulsoup4 library, which fixes a bug that was causing invalid xml to be generated.

--- a/setup.py
+++ b/setup.py
@@ -16,13 +16,13 @@ dependencies = [
 ]
 
 setup(
-    name='pycaption',
-    version='1.1.0',
+    name='pycaption-od',
+    version='1.0.0',
     description='Closed caption converter',
     long_description=open(README_PATH).read(),
-    author='Joe Norton',
-    author_email='joey@nortoncrew.com',
-    url='https://github.com/pbs/pycaption',
+    author='OverDrive',
+    author_email='ktighe@overdrive.com',
+    url='https://github.com/ktighe-od/pycaption-od',
     install_requires=dependencies,
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README_PATH = os.path.join(
     'README.rst')
 
 dependencies = [
-    'beautifulsoup4>=4.2.1,<4.5.0',
+    'beautifulsoup4>=4.8.2',
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',


### PR DESCRIPTION
We are having a problem where pycaption is generating invalid xml.  In particular, this line (notice the extra colon in xmlns:="..."):

```
<tt xml:lang="en" xmlns:="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling">
```

Running the unit tests exposed this problem as well.  I upgraded the beautifulsoup4 dependency to >=4.8.2, which corrects the problem.  All unit tests pass.