### PR TITLE
Remove Python 3.4 and add 3.6, 3.7 and 3.8 to Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: python
 
 python:
-    - 3.4
     - 3.5
+    - 3.6
+    - 3.7
+    - 3.8
 
 script: python setup.py test
 


### PR DESCRIPTION
Python 3.4 tests will just fail because libraries pulled in no longer support 3.4. While here, add the newer versions to the list.