### PR TITLE
Python 3.7 upgrade preparation: Remove enum34 dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,5 +30,5 @@ License
 This module is Copyright 2012 PBS.org and is available under the `Apache
 License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>`__.
 
-.. |Build Status| image:: https://travis-ci.org/udemy/pycaption.png?branch=master
+.. |Build Status| image:: https://travis-ci.com/udemy/pycaption.svg?branch=master
    :target: https://travis-ci.org/udemy/pycaption

--- a/README.rst
+++ b/README.rst
@@ -30,5 +30,5 @@ License
 This module is Copyright 2012 PBS.org and is available under the `Apache
 License, Version 2.0 <http://www.apache.org/licenses/LICENSE-2.0>`__.
 
-.. |Build Status| image:: https://travis-ci.org/pbs/pycaption.png?branch=master
-   :target: https://travis-ci.org/pbs/pycaption
+.. |Build Status| image:: https://travis-ci.org/udemy/pycaption.png?branch=master
+   :target: https://travis-ci.org/udemy/pycaption

--- a/pycaption/base.py
+++ b/pycaption/base.py
@@ -181,8 +181,6 @@ class Caption(object):
         if not isinstance(end, Number):
             raise CaptionReadTimingError("Captions must be initialized with a"
                                          " valid end time")
-        if not nodes:
-            raise CaptionReadError("Node list cannot be empty")
         self.start = start
         self.end = end
         self.nodes = nodes

--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -93,15 +93,10 @@ class WebVTTReader(BaseReader):
 
             elif '' == line:
                 if found_timing:
-                    if not nodes:
-                        raise CaptionReadSyntaxError(
-                            'Cue without content. (line %d)' % timing_line)
-                    else:
-                        found_timing = False
-                        caption = Caption(
-                            start, end, nodes, layout_info=layout_info)
-                        captions.append(caption)
-                        nodes = []
+                    found_timing = False
+                    caption = Caption(start, end, nodes, layout_info=layout_info)
+                    captions.append(caption)
+                    nodes = []
             else:
                 if found_timing:
                     if nodes:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README_PATH = os.path.join(
     'README.rst')
 
 dependencies = [
-    'beautifulsoup4>=4.2.1,<4.5.0',
+    'beautifulsoup4>=4.2.1,<4.6.0',
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ README_PATH = os.path.join(
     'README.rst')
 
 dependencies = [
-    'beautifulsoup4>=4.2.1,<4.6.0',
+    'beautifulsoup4>=4.2.1,<=4.6.0',
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',
@@ -17,7 +17,7 @@ dependencies = [
 
 setup(
     name='pycaption',
-    version='1.1.0.ud3',
+    version='1.1.0.ud4',
     description='Closed caption converter',
     long_description=open(README_PATH).read(),
     author='Joe Norton',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ dependencies = [
     'lxml>=3.2.3',
     'cssutils>=0.9.10',
     'future',
-    'enum34',
     'six>=1.9.0'
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ dependencies = [
 
 setup(
     name='pycaption',
-    version='1.1.0.ud1',
+    version='1.1.0.ud3',
     description='Closed caption converter',
     long_description=open(README_PATH).read(),
     author='Joe Norton',

--- a/setup.py
+++ b/setup.py
@@ -17,12 +17,12 @@ dependencies = [
 
 setup(
     name='pycaption',
-    version='1.1.0',
+    version='1.1.0.ud1',
     description='Closed caption converter',
     long_description=open(README_PATH).read(),
     author='Joe Norton',
     author_email='joey@nortoncrew.com',
-    url='https://github.com/pbs/pycaption',
+    url='https://github.com/udemy/pycaption',
     install_requires=dependencies,
     packages=find_packages(),
     include_package_data=True,

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -127,16 +127,6 @@ class WebVTTReaderTestCase(unittest.TestCase):
 
     def test_invalid_files(self):
         self.assertRaises(
-            CaptionReadSyntaxError,
-            WebVTTReader().read,
-            ("\nNOTE Cues without text are invalid.\n"
-                "00:00:20.000 --> 00:00:30.000\n"
-                "\n"
-                "00:00:40.000 --> 00:00:50.000\n"
-                "foo bar baz\n")
-        )
-
-        self.assertRaises(
             CaptionReadError,
             WebVTTReader(ignore_timing_errors=False).read,
             ("00:00:20.000 --> 00:00:10.000\n"


### PR DESCRIPTION
This PR removes a dependency on enum34 which interferes with `line-profiler` lib install, and which is not required for Python versions since 3.4 when it was included in the standard library (see https://www.python.org/dev/peps/pep-0435/). I verified that the standard library version is being used when importing `Enum` and so its removal should not have any side effects given that we are currently using Python 3.5.