### PR TITLE
pycaption/webvtt.py: Add languge param to WebVTT.write()

### DIFF
--- a/docs/supported_formats.rst
+++ b/docs/supported_formats.rst
@@ -51,6 +51,14 @@ specification is currently (as of February 2015) in draft stage and
 therefore not all features are implemented by major players, the same
 being true for ``pycaption``.
 
+By default, the reader assumes the language is English and the writer
+returns the first language it finds in the caption set. You can specify
+a language using the ``lang`` parameter:
+
+::
+
+    pycaps = WebVTTReader().read(content, lang='fr')
+
 Styling
 ^^^^^^^
 

--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -202,9 +202,10 @@ class WebVTTWriter(BaseWriter):
     video_width = None
     video_height = None
 
-    def write(self, caption_set, language=None):
+    def write(self, caption_set, lang=None):
         """
         :type caption_set: CaptionSet
+        :type lang: str
         """
         output = self.HEADER
 
@@ -217,10 +218,8 @@ class WebVTTWriter(BaseWriter):
         # fit the API here. Figure that out.  Though some style stuff can be
         # done in-line.  This format is a little bit crazy.
 
-        if language is None:
+        if lang is None:
             lang = list(caption_set.get_languages())[0]
-        else:
-            lang = language
 
         self.global_layout = caption_set.get_layout_info(lang)
 

--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -219,7 +219,7 @@ class WebVTTWriter(BaseWriter):
         # done in-line.  This format is a little bit crazy.
 
         if lang is None:
-            lang = list(caption_set.get_languages())[0]
+            lang = caption_set.get_languages()[0]
 
         self.global_layout = caption_set.get_layout_info(lang)
 

--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -202,7 +202,7 @@ class WebVTTWriter(BaseWriter):
     video_width = None
     video_height = None
 
-    def write(self, caption_set):
+    def write(self, caption_set, language=None):
         """
         :type caption_set: CaptionSet
         """
@@ -219,7 +219,10 @@ class WebVTTWriter(BaseWriter):
 
         # WebVTT's language support seems to be a bit crazy, so let's just
         # support a single one for now.
-        lang = list(caption_set.get_languages())[0]
+        if language is None:
+            lang = list(caption_set.get_languages())[0]
+        else:
+            lang = language
 
         self.global_layout = caption_set.get_layout_info(lang)
 

--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -217,8 +217,6 @@ class WebVTTWriter(BaseWriter):
         # fit the API here. Figure that out.  Though some style stuff can be
         # done in-line.  This format is a little bit crazy.
 
-        # WebVTT's language support seems to be a bit crazy, so let's just
-        # support a single one for now.
         if language is None:
             lang = list(caption_set.get_languages())[0]
         else:

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -424,3 +424,17 @@ SAMPLE_SAMI_WITH_LANG = """
 </body>
 </sami>
 """
+
+SAMPLE_SAMI_WITH_MULTI_LANG = """
+<sami>
+<head>
+<style type="text/css"><!--.en-US {lang: en-US;} .de-DE {lang: de-DE;}--></style>
+</head>
+<body>
+<sync start="14848">
+    <p class="en-US">Butterfly.</p>
+    <p class="de-DE">Schmetterling.</p>
+</sync>
+</body>
+</sami>
+"""

--- a/tests/samples/webvtt.py
+++ b/tests/samples/webvtt.py
@@ -254,3 +254,15 @@ SAMPLE_WEBVTT_EMPTY_CUE = """WEBVTT
 00:04.000 --> 00:05.000
 Transcribed by Celestials
 """
+
+SAMPLE_WEBVTT_MULTI_LANG_EN = """WEBVTT
+
+00:14.848 --> 00:18.848
+Butterfly.
+"""
+
+SAMPLE_WEBVTT_MULTI_LANG_DE = """WEBVTT
+
+00:14.848 --> 00:18.848
+Schmetterling.
+"""

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -4,15 +4,16 @@ from pycaption import (
     WebVTTReader, WebVTTWriter, SAMIReader, DFXPReader,
     CaptionReadNoCaptions, CaptionReadError, CaptionReadSyntaxError
 )
-
 from tests.samples.dfxp import DFXP_STYLE_REGION_ALIGN_CONFLICT
-from tests.samples.sami import SAMPLE_SAMI_DOUBLE_BR
+from tests.samples.sami import SAMPLE_SAMI_DOUBLE_BR, \
+    SAMPLE_SAMI_WITH_MULTI_LANG
 from tests.samples.srt import SAMPLE_SRT
 from tests.samples.webvtt import (
+    SAMPLE_WEBVTT_EMPTY_CUE,
     SAMPLE_WEBVTT, SAMPLE_WEBVTT_2, SAMPLE_WEBVTT_EMPTY,
     SAMPLE_WEBVTT_DOUBLE_BR,
     WEBVTT_FROM_DFXP_WITH_CONFLICTING_ALIGN, SAMPLE_WEBVTT_LAST_CUE_ZERO_START,
-    SAMPLE_WEBVTT_EMPTY_CUE
+    SAMPLE_WEBVTT_MULTI_LANG_DE, SAMPLE_WEBVTT_MULTI_LANG_EN
 )
 
 
@@ -132,17 +133,17 @@ class WebVTTReaderTestCase(unittest.TestCase):
             CaptionReadError,
             WebVTTReader(ignore_timing_errors=False).read,
             ("00:00:20.000 --> 00:00:10.000\n"
-                "Start time is greater than end time.")
+             "Start time is greater than end time.")
         )
 
         self.assertRaises(
             CaptionReadError,
             WebVTTReader(ignore_timing_errors=False).read,
             ("00:00:20.000 --> 00:00:30.000\n"
-                "Start times should be consecutive.\n"
-                "\n"
-                "00:00:10.000 --> 00:00:20.000\n"
-                "This cue starts before the previous one.\n")
+             "Start times should be consecutive.\n"
+             "\n"
+             "00:00:10.000 --> 00:00:20.000\n"
+             "This cue starts before the previous one.\n")
         )
 
     def test_zero_start(self):
@@ -152,7 +153,7 @@ class WebVTTReaderTestCase(unittest.TestCase):
 
     def test_webvtt_empty_cue(self):
         self.assertEqual(1, len(self.reader.read(
-                SAMPLE_WEBVTT_EMPTY_CUE).get_captions('en-US')))
+            SAMPLE_WEBVTT_EMPTY_CUE).get_captions('en-US')))
 
 
 class WebVTTWriterTestCase(unittest.TestCase):
@@ -169,3 +170,10 @@ class WebVTTWriterTestCase(unittest.TestCase):
         caption_set = DFXPReader().read(DFXP_STYLE_REGION_ALIGN_CONFLICT)
         results = WebVTTWriter().write(caption_set)
         self.assertEqual(WEBVTT_FROM_DFXP_WITH_CONFLICTING_ALIGN, results)
+
+    def test_lang_option(self):
+        caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_MULTI_LANG)
+        results = WebVTTWriter().write(caption_set, 'de-DE')
+        self.assertEqual(SAMPLE_WEBVTT_MULTI_LANG_DE, results)
+        results = WebVTTWriter().write(caption_set, 'en-US')
+        self.assertEqual(SAMPLE_WEBVTT_MULTI_LANG_EN, results)


### PR DESCRIPTION
If a CaptionSet has multiple language the vtt write should be able to select between the
the languages. This param allows the language selection.

(cherry picked from commit bbdff88f65962a3877e9d7ee1800c317deef9f09)
PR update for #153 - fixed conflicts with master