### PR TITLE
Fix end time caption for sami format

### DIFF
--- a/pycaption/sami.py
+++ b/pycaption/sami.py
@@ -199,8 +199,13 @@ class SAMIReader(BaseReader):
             start = milliseconds * 1000
             end = 0
 
-            if captions != [] and captions[-1].end == 0:
-                captions[-1].end = milliseconds * 1000
+            if captions != []:
+                i = len(captions) - 1
+                while (captions[i].end == 0) and (i >= 0):
+                    # if the parent of multiple  <p> are same:
+                    if captions[i].start != start:
+                        captions[i].end = start
+                    i = i - 1
 
             if p.get_text().strip():
                 self.first_alignment = None

--- a/pycaption/sami.py
+++ b/pycaption/sami.py
@@ -199,13 +199,13 @@ class SAMIReader(BaseReader):
             start = milliseconds * 1000
             end = 0
 
-            if captions != []:
-                i = len(captions) - 1
-                while (captions[i].end == 0) and (i >= 0):
-                    # if the parent of multiple  <p> are same:
-                    if captions[i].start != start:
-                        captions[i].end = start
-                    i = i - 1
+            # Setting current start time as end time for previous elements with 0 as ending
+            # ( when we have more p elements inside a SYNC element )
+            for i in reversed(range(len(captions))):
+                if captions[i].end != 0:
+                    break
+                if captions[i].start != start:
+                    captions[i].end = start
 
             if p.get_text().strip():
                 self.first_alignment = None

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -438,3 +438,31 @@ SAMPLE_SAMI_WITH_MULTI_LANG = """
 </body>
 </sami>
 """
+
+SAMPLE_SAMI_WITH_MULTIPLE_P = """
+<SAMI>
+<HEAD>
+    <STYLE TYPE="Text/css">
+    <!--
+        P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
+        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+    -->
+    </STYLE>
+</HEAD>
+<BODY>
+    <SYNC start="133">
+        <P class="ENCC" Style="text-align:right;">
+            1st paragraph.
+        </P>
+        <P class="ENCC" Style="text-align:left;">
+           2nd paragraph.
+        </P>
+    </SYNC>
+    <SYNC start="1337">
+        <P class="ENCC" Style="text-align:right;">
+            3rd paragraph.
+        </P>
+    </SYNC>
+</BODY>
+</SAMI>
+"""

--- a/tests/samples/sami.py
+++ b/tests/samples/sami.py
@@ -445,7 +445,7 @@ SAMPLE_SAMI_WITH_MULTIPLE_P = """
     <STYLE TYPE="Text/css">
     <!--
         P {font-size: 24pt; text-align: center; font-family: Tahoma; font-weight: bold; color: #FFFFFF; background-color: #000000;}
-        .SUBTTL {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
+        .ENCC {Name: 'Subtitles'; Lang: en-US; SAMIType: CC; margin-top: 20px; margin-right: 20px; margin-bottom: 20px; margin-left: 20px;}
     -->
     </STYLE>
 </HEAD>

--- a/tests/test_sami.py
+++ b/tests/test_sami.py
@@ -8,7 +8,7 @@ from tests.samples.sami import (
     SAMPLE_SAMI, SAMPLE_SAMI_EMPTY, SAMPLE_SAMI_SYNTAX_ERROR,
     SAMPLE_SAMI_PARTIAL_MARGINS, SAMPLE_SAMI_WITH_BAD_SPAN_ALIGN,
     SAMPLE_SAMI_WITH_BAD_DIV_ALIGN, SAMPLE_SAMI_WITH_P_ALIGN,
-    SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN
+    SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN, SAMPLE_SAMI_WITH_MULTIPLE_P
 )
 
 class SAMIReaderTestCase(unittest.TestCase):
@@ -81,3 +81,10 @@ class SAMIReaderTestCase(unittest.TestCase):
         caption_set = SAMIReader().read(SAMPLE_SAMI_WITH_P_AND_SPAN_ALIGN)
         caption = caption_set.get_captions('en-US')[0]
         self.assertEqual(caption.layout_info.alignment.horizontal, HorizontalAlignmentEnum.RIGHT)
+
+    def test_proper_with_timestamps_with_multiple_paragraph(self):
+        captions = SAMIReader().read(SAMPLE_SAMI_WITH_MULTIPLE_P)
+        paragraph_1 = captions.get_captions("en-US")[0]
+        paragraph_2 = captions.get_captions("en-US")[1]
+        self.assertEqual(paragraph_1.start, paragraph_2.start)
+        self.assertEqual(paragraph_1.end, paragraph_2.end)


### PR DESCRIPTION
"If a <sync> element has multiple <p>, All end time will be incorrect except the last one.
From now, The start times of previous captions are compared with the current element. If the
start times are different and the previuos end time is 0, the previous end time is set to
the current start time."