### PR TITLE
Fix subtitle merge of an empty caption

### DIFF
--- a/pycaption/base.py
+++ b/pycaption/base.py
@@ -380,17 +380,18 @@ def merge_concurrent_captions(caption_set):
         concurrent_captions = CaptionList()
         merged_captions = CaptionList()
         for caption in captions:
-            if last_caption:
-                last_timespan = last_caption.start, last_caption.end
-                current_timespan = caption.start, caption.end
-                if current_timespan == last_timespan:
-                    concurrent_captions.append(caption)
-                    last_caption = caption
-                    continue
-                else:
-                    merged_captions.append(merge(concurrent_captions))
-            concurrent_captions = [caption]
-            last_caption = caption
+            if caption != None:
+                if last_caption:
+                    last_timespan = last_caption.start, last_caption.end
+                    current_timespan = caption.start, caption.end
+                    if current_timespan == last_timespan:
+                        concurrent_captions.append(caption)
+                        last_caption = caption
+                        continue
+                    else:
+                        merged_captions.append(merge(concurrent_captions))
+                concurrent_captions = [caption]
+                last_caption = caption
 
         if concurrent_captions:
             merged_captions.append(merge(concurrent_captions))

--- a/pycaption/srt.py
+++ b/pycaption/srt.py
@@ -105,14 +105,15 @@ class SRTWriter(BaseWriter):
 
         for caption in captions[1:]:
             # Merge if the timestamp is the same as last caption
-            if (caption.start, caption.end) == (merged_captions[-1].start, merged_captions[-1].end):
-                merged_captions[-1] = Caption(
-                    start=caption.start,
-                    end=caption.end,
-                    nodes=merged_captions[-1].nodes + caption.nodes)
-            else:
-                # Different timestamp, end of merging, append new caption
-                merged_captions.append(caption)
+            if caption != None:
+                if (caption.start, caption.end) == (merged_captions[-1].start, merged_captions[-1].end):
+                    merged_captions[-1] = Caption(
+                        start=caption.start,
+                        end=caption.end,
+                        nodes=merged_captions[-1].nodes + caption.nodes)
+                else:
+                    # Different timestamp, end of merging, append new caption
+                    merged_captions.append(caption)
         captions = merged_captions
 
         srt = ''


### PR DESCRIPTION
#### This fix the error: 
> AttributeError: 'NoneType' object has no attribute 'start'

#### Explaining the error:
> It is caused because the caption has a blank value, a blank caption with no text, this causes the default code that joins the subtitles to go into error, as it cannot join a received None value, with an existing String value, and ends up breaking the subtitle conversion.

#### Problem example (DFXP/SMPTE xml):
```xml
<p region='pop1' style='basic' begin='01:55:05:08' end='01:55:11:14' tts:origin='17.5% 84.66%' tts:extent='62.5% 5.33%'>Subtitle End</p>
<p region='pop2' style='basic' begin='01:55:05:08' end='01:55:11:14' tts:origin='50% 84.66%' tts:extent='0% 5.33%'></p>
