### PR TITLE
Add a newline between merged captions with overlapping timestamps

### DIFF
--- a/pycaption/srt.py
+++ b/pycaption/srt.py
@@ -109,7 +109,7 @@ class SRTWriter(BaseWriter):
                 merged_captions[-1] = Caption(
                     start=caption.start,
                     end=caption.end,
-                    nodes=merged_captions[-1].nodes + caption.nodes)
+                    nodes=merged_captions[-1].nodes + [CaptionNode.create_break()] + caption.nodes)
             else:
                 # Different timestamp, end of merging, append new caption
                 merged_captions.append(caption)

--- a/tests/test_srt.py
+++ b/tests/test_srt.py
@@ -47,4 +47,4 @@ class SRTReaderTestCase(unittest.TestCase):
         sentences = (re.split(r"\d{2}:\d{2}:\d{2},\d{3} -->", results))
         sentences.pop(0)
         self.assertEqual(3, len(sentences))
-
+        self.assertEqual(5, len(sentences[0].splitlines()))


### PR DESCRIPTION
The previous fix just concatenated them with a space, however when there is a separate cue with overlapping timestamps it should be displayed on a new line.