### PR TITLE
Don't force <3.10, instead force 3.x (<4.x)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author='Joe Norton',
     author_email='joey@nortoncrew.com',
     url='https://github.com/pbs/pycaption',
-    python_requires='>=3.6,<3.10',
+    python_requires='>=3.6,<4.0',
     install_requires=dependencies,
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
Almost every other package does this, as they don't want to restrict or make updates to newer python minor releases any difficult if the package isn't updated fast enough.
There's no current reason that I can see at least, for the project to forcefully restrict no support at all on 3.10 yet.

Any project that requires pycaption ^2.0.0, will now also have to restrict their packages from `<4.0`  to `<3.10`  which is not great.