### PR TITLE
Dynamic FPS selection on DFXPReader

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from tests.fixtures.dfxp import (  # noqa: F401
     sample_dfxp_invalid_positioning_value_template,
     sample_dfxp_multiple_captions_with_the_same_timing,
     sample_dfxp_with_ampersand_character, sample_dfxp_with_nested_spans,
-    dfxp_style_region_align_conflict, dfxp_with_concurrent_captions,
+    dfxp_style_region_align_conflict, dfxp_with_concurrent_captions, sample_dfxp_framerate
 )
 from tests.fixtures.microdvd import (  # noqa: F401
     sample_microdvd, sample_microdvd_2,

--- a/tests/fixtures/dfxp.py
+++ b/tests/fixtures/dfxp.py
@@ -1509,3 +1509,48 @@ def sample_dfxp_default_styling_p_tags():
   </div>
  </body>
 </tt>"""
+
+
+@pytest.fixture(scope="session")
+def sample_dfxp_framerate():
+    return """\
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/ns/ttml" 
+    xmlns:tts="http://www.w3.org/ns/ttml#styling" 
+    xmlns:ttm="http://www.w3.org/ns/ttml#metadata" 
+        xmlns:ttp="http://www.w3.org/ns/ttml#parameter" 
+        xmlns:smpte="http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt" 
+        xmlns:m608="http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt#cea608" 
+        ttp:timeBase="media" ttp:frameRate="24" ttp:frameRateMultiplier="1000 1001">
+    <head>
+        <metadata>
+            <ttm:desc>SMPTE 2052 Timed Text Captions document created by MacCaption™ version 7.0.12</ttm:desc>
+            <smpte:information xmlns:m608="http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt#cea608" 
+            origin="http://www.smpte-ra.org/schemas/2052-1/2010/smpte-tt#cea608" 
+            mode="Preserved" m608:channel="CC1" m608:programName="Demo" m608:captionService="F1C1CC"/>
+        </metadata>
+        <styling>
+            <style xml:id="basic" tts:color="white" tts:backgroundColor="black" tts:showBackground="whenActive" 
+            tts:fontFamily="monospace" tts:fontSize="80%" tts:fontWeight="normal" tts:fontStyle="normal"/>
+        </styling>
+        <layout>
+            <region xml:id="pop1" tts:backgroundColor="transparent" tts:showBackground="whenActive"/>
+            <region xml:id="pop2" tts:backgroundColor="transparent" tts:showBackground="whenActive"/>
+            <region xml:id="pop3" tts:backgroundColor="transparent" tts:showBackground="whenActive"/>
+            <region xml:id="pop4" tts:backgroundColor="transparent" tts:showBackground="whenActive"/>
+        </layout>
+    </head>
+    <body>
+        <div>
+            <p begin="00:00:00:15" end="00:00:08:05" region="bottom" style="default">
+            MAN 2:<br/>
+            E equals m c-squared is<br/>
+            not about an old Einstein.
+           </p>
+           <p begin="00:00:08:05" end="00:00:09:16" region="bottom" style="default">
+            MAN 2:<br/>
+            It's all about an eternal Einstein.
+           </p>
+        </div>
+    </body>
+</tt>"""

--- a/tests/test_dfxp.py
+++ b/tests/test_dfxp.py
@@ -40,6 +40,13 @@ class TestDFXPReader(ReaderTestingMixIn):
         assert 17000000 == paragraph.start
         assert 18752000 == paragraph.end
 
+    def test_proper_timestamps_framerate(self, sample_dfxp_framerate):
+        captions = DFXPReader().read(sample_dfxp_framerate)
+        paragraph = captions.get_captions("en")[1]
+
+        assert 8208541 == paragraph.start
+        assert 9667333 == paragraph.end
+
     def test_incorrect_time_format(self, sample_dfxp_incorrect_time_format):
         with pytest.raises(CaptionReadTimingError) as exc_info:
             DFXPReader().read(sample_dfxp_incorrect_time_format)
@@ -70,6 +77,13 @@ class TestDFXPReader(ReaderTestingMixIn):
         # Tick values are not supported
         with pytest.raises(NotImplementedError):
             reader._convert_timestamp_to_microseconds("2.3t")
+
+    def test_convert_timestamp_to_microseconds_framerate(self):
+        reader = DFXPReader()
+        reader.framerate = 24
+
+        assert 66666 == reader._convert_timestamp_to_microseconds("1.6f")
+        assert 625000 == reader._convert_timestamp_to_microseconds("00:00:00:15")
 
     @pytest.mark.parametrize('timestamp, microseconds', [
         ('12:23:34', 44614000000), ('23:34:45:56', 84886866666),


### PR DESCRIPTION
The methods `_convert_clock_time_to_microseconds `and `_convert_time_count_to_microseconds`  are fixed to 30fps. 

The modified code uses 30fps by default but also looks for an alternative frame rate on the CloseCaption file.