### PR TITLE
sort scc captions before writing

### DIFF
--- a/pycaption/scc/__init__.py
+++ b/pycaption/scc/__init__.py
@@ -572,14 +572,22 @@ class SCCWriter(BaseWriter):
 
         # PASS 3:
         # Write captions.
+        captions = []
         for code, start, end in codes:
-            output += f"{self._format_timestamp(start)}\t"
-            output += "94ae 94ae 9420 9420 "
-            output += code
-            output += "942c 942c 942f 942f\n\n"
+            caption = f"{self._format_timestamp(start)}\t"
+            caption += "94ae 94ae 9420 9420 "
+            caption += code
+            caption += "942c 942c 942f 942f"
+            captions.append((start, caption))
             if end is not None:
-                output += f"{self._format_timestamp(end)}\t942c 942c\n\n"
+                captions.append((end, f"{self._format_timestamp(end)}\t942c 942c"))
 
+        # PASS 4:
+        # Sort captions.
+        list.sort(captions, key=lambda caption: caption[0])
+        captions = ["%s" % code[1] for code in captions]
+
+        output += "\n\n".join(captions)
         return output
 
     # Wrap lines at 32 chars


### PR DESCRIPTION
### Issue
In certain scenarios due to buffering calculations, SCC caption output is no longer in order. This manifests when short caption text is followed by longer caption text.

fixes #352 

### Example
VTT Source
```
WEBVTT

0
00:00:02.200 --> 00:00:02.359
you know,

1
00:00:02.400 --> 00:00:03.760
the way he kind of looked at me.

2
00:00:04.700 --> 00:00:05.169
And I said,

3
00:00:05.210 --> 00:00:05.520
oh
```

SCC Output
```
Scenarist_SCC V1.0

00:00:02:05	94ae 94ae 9420 9420 9470 9470 79ef 7520 6b6e eff7 2c80 942c 942c 942f 942f

00:00:01:15	94ae 94ae 9420 9420 9470 9470 f468 e520 f761 7920 68e5 206b e96e 6420 efe6 20ec efef 6be5 6420 61f4 206d e5ae 942c 942c 942f 942f

00:00:03:22	942c 942c

00:00:04:04	94ae 94ae 9420 9420 9470 9470 c16e 6420 4920 7361 e964 2c80 942c 942c 942f 942f

00:00:04:25	94ae 94ae 9420 9420 9470 9470 ef68 942c 942c 942f 942f

00:00:05:15	942c 942c
```

### Solution

Adding a post processing step in the `SCCWriter().write()` method to sort captions by timestamp.

New output that is in order:
```
Scenarist_SCC V1.0

00:00:01:15	94ae 94ae 9420 9420 9470 9470 f468 e520 f761 7920 68e5 206b e96e 6420 efe6 20ec efef 6be5 6420 61f4 206d e5ae 942c 942c 942f 942f

00:00:02:05	94ae 94ae 9420 9420 9470 9470 79ef 7520 6b6e eff7 2c80 942c 942c 942f 942f

00:00:03:22	942c 942c

00:00:04:04	94ae 94ae 9420 9420 9470 9470 c16e 6420 4920 7361 e964 2c80 942c 942c 942f 942f

00:00:04:25	94ae 94ae 9420 9420 9470 9470 ef68 942c 942c 942f 942f

00:00:05:15	942c 942c
```