### PR TITLE
OCTO-11227 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,13 @@
 Changelog
 ---------
+2.2.24
+^^^^^^
+  - Fix SCC ingestion error when a doubled italic-off mid-row code
+    (9120 9120) appears before punctuation. The punctuation lookahead
+    now skips the error-correction duplicate, preventing an unwanted
+    space that pushed lines past the 32-character limit.
+
+
 2.2.23
 ^^^^^^
   - bumps nltk from 3.9.1 to 3.9.4.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,7 @@ copyright = "2012-2026, PBS.org " \
 # built documents.
 #
 # The short X.Y version.
-version = "2.2.23"
+version = "2.2.24.dev1"
 # The full version, including alpha/beta/rc tags.
 release = "2.2.23"
 

--- a/pycaption/scc/__init__.py
+++ b/pycaption/scc/__init__.py
@@ -332,7 +332,15 @@ class SCCReader(BaseReader):
         for idx, word in enumerate(word_list):
             word = word.strip()
             if len(word) == 4:
-                next_command = word_list[idx + 1] if idx + 1 < len(word_list) else None
+                # Look ahead for the next command, skipping the duplicate
+                # that SCC uses for error-correction (same word repeated).
+                next_idx = idx + 1
+                if (next_idx < len(word_list)
+                        and word_list[next_idx].strip() == word):
+                    next_idx += 1
+                next_command = (
+                    word_list[next_idx] if next_idx < len(word_list) else None
+                )
                 self._translate_word(word=word, next_command=next_command)
 
     def _translate_word(self, word, next_command=None):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ transcript_dependencies = ["nltk==3.9.4"]
 
 setup(
     name="pycaption",
-    version="2.2.23",
+    version="2.2.24.dev1",
     description="Closed caption converter",
     long_description=open(README_PATH).read(),
     author="Joe Norton",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,7 @@ from tests.fixtures.scc import (  # noqa: F401
     sample_no_positioning_at_all_scc,
     sample_scc_created_dfxp_with_wrongly_closing_spans,
     sample_scc_duplicate_special_characters,
+    sample_scc_doubled_mid_row_before_punctuation,
     sample_scc_duplicate_tab_offset,
     sample_scc_empty,
     sample_scc_eoc_first_command,

--- a/tests/fixtures/scc.py
+++ b/tests/fixtures/scc.py
@@ -659,3 +659,13 @@ Scenarist_SCC V1.0
 00:00:04;00	942c
 
 """
+
+
+@pytest.fixture(scope="session")
+def sample_scc_doubled_mid_row_before_punctuation():
+    return """\
+Scenarist_SCC V1.0
+
+00:26:48;29\t9420 9420 94d0 94d0 97a1 97a1 3e3e 2057 e5a7 ecec 2062 e520 6261 e36b 206e e5f8 f420 f7e5 e56b 20f7 e9f4 6880 9470 9470 616e eff4 68e5 f220 e570 e973 ef64 e520 efe6 91ae 91ae 4361 6e61 6461 2046 e9ec e573 9120 9120 ae80 942c 942c 8080 8080 942f 942f
+
+"""

--- a/tests/test_scc.py
+++ b/tests/test_scc.py
@@ -392,6 +392,24 @@ class TestSCCReader(ReaderTestingMixIn):
             ]
             assert expected_lines == actual_lines
 
+    def test_doubled_mid_row_before_punctuation_no_extra_space(
+        self,
+        sample_scc_doubled_mid_row_before_punctuation,
+    ):
+        caption_set = SCCReader().read(
+            sample_scc_doubled_mid_row_before_punctuation
+        )
+        captions = caption_set.get_captions("en-US")
+        text_nodes = [
+            node.content
+            for cap_ in captions
+            for node in cap_.nodes
+            if node.type_ == CaptionNode.TEXT
+        ]
+        full_text = "".join(text_nodes)
+        assert " ." not in full_text
+        assert full_text.endswith("Files.")
+
     def test_removing_spaces_at_end_of_lines(
         self,
         sample_scc_with_spaces_at_eol_pop,


### PR DESCRIPTION
 SCC files double every control code for error correction. So 9120 (italic off / white plain) is always sent as 9120 9120. The decoder sees the pair and ignores the second one.

  When pycaption processes a mid-row code like 9120, it looks at the next word in the hex stream to decide whether to insert a space. If the next word starts with a punctuation byte (ae = period, a1 = exclamation, etc.), it skips the space.

  In the failing file, the sequence is:

  ...9120 9120 ae80...
           ↑        ↑
       duplicate   period

  When processing the first 9120:

next_command = "9120" (the duplicate)

next_command[:2] = "91" — NOT punctuation

Space gets inserted → "Files ." → 33 chars → error

  The Fix

  If the next word is identical to the current word (it's the duplicate), skip it and look one further. Now when processing the first 9120:

Sees word_list[idx+1] = "9120" = same as current word → skip

next_command = "ae80" (the period)

next_command[:2] = "ae" — IS punctuation

Space is suppressed → "Files." → 32 chars → passes