### PR TITLE
OCTO-11500-Harden-the-WebVTT-reader-against-malformed-input

### DIFF
--- a/.claude/skills/check-vtt-compliance/skill.md
+++ b/.claude/skills/check-vtt-compliance/skill.md
@@ -70,6 +70,13 @@ landmarks = {
     'def read (WebVTTReader)': (webvtt_file, r'def\s+read\b'),
     'def write (WebVTTWriter)': (webvtt_file, r'def\s+write\b'),
     'class Layout': ('pycaption/geometry.py', r'class\s+Layout\b'),
+    'def _parse_cue_settings': (webvtt_file, r'def\s+_parse_cue_settings\b'),
+    'def _parse_style_blocks': (webvtt_file, r'def\s+_parse_style_blocks\b'),
+    'CUE_SETTING_PATTERN': (webvtt_file, r'CUE_SETTING_PATTERN\s*=\s*re\.compile'),
+    'STYLE_SELECTOR_PATTERN': (webvtt_file, r'STYLE_SELECTOR_PATTERN\s*=\s*re\.compile'),
+    'TAG_SPLIT_PATTERN': (webvtt_file, r'TAG_SPLIT_PATTERN\s*=\s*re\.compile'),
+    'def _classify_tag': (webvtt_file, r'def\s+_classify_tag\b'),
+    'WritingDirectionEnum': ('pycaption/geometry.py', r'class\s+WritingDirectionEnum\b'),
 }
 stale_warnings = []
 for name, (expected_file, pattern) in landmarks.items():
@@ -94,15 +101,13 @@ print("\n[1/5] Deep Validation Analysis")
 deep_results = {}
 
 # RULE-FMT-001: WEBVTT header detection
-# The detect() method uses substring check: '"WEBVTT" in content'
-# This is overly permissive (matches WEBVTT anywhere, not just first line)
-has_header_detect = bool(re.search(r'def detect.*\n.*"WEBVTT"\s+in\s+content', content))
-has_header_validate = bool(re.search(r'content\s*\[\s*:6\s*\]\s*==|startswith.*WEBVTT|^WEBVTT', content))
+has_header_validate = bool(re.search(r'def _validate_header|startswith.*"WEBVTT ', content))
+has_detect_first_line = bool(re.search(r'first_line\s*==\s*"WEBVTT"|first_line\.startswith\("WEBVTT', content))
 deep_results['RULE-FMT-001'] = {
     'name': 'WEBVTT header',
-    'detected': has_header_detect,
-    'validated': has_header_validate,
-    'note': 'detect() uses substring check, not first-line validation' if has_header_detect and not has_header_validate else '',
+    'detected': has_header_validate or has_detect_first_line,
+    'validated': has_header_validate and has_detect_first_line,
+    'note': '' if (has_header_validate and has_detect_first_line) else 'Header validation incomplete',
 }
 
 # RULE-FMT-002: UTF-8 encoding
@@ -156,17 +161,17 @@ deep_results['RULE-TIME-006'] = {
 }
 
 # RULE-CUE-001: Timing separator ' --> '
-has_arrow_pattern = bool(re.search(r'-->|TIMING_LINE_PATTERN', content))
+# Only match the TIMING_LINE_PATTERN definition, not general '-->' usage in style/note handling
+has_timing_pattern = bool(re.search(r'TIMING_LINE_PATTERN\s*=\s*re\.compile', content))
+has_timing_parse = bool(re.search(r'TIMING_LINE_PATTERN\.match|TIMING_LINE_PATTERN\.search', content))
 deep_results['RULE-CUE-001'] = {
     'name': 'Timing separator -->',
-    'detected': has_arrow_pattern,
-    'validated': has_arrow_pattern,
+    'detected': has_timing_pattern,
+    'validated': has_timing_pattern and has_timing_parse,
     'note': 'TIMING_LINE_PATTERN captures arrow with surrounding whitespace',
 }
 
 # RULE-SET-002: Zero-value positions silently dropped on write
-# Writer uses `if left_offset:` which is falsy for 0 — a valid position value
-# Should be `if left_offset is not None:`
 writer_section = content.split('class WebVTTWriter')[1] if 'class WebVTTWriter' in content else ''
 zero_pos_bug = bool(re.search(r'if left_offset:', writer_section)) and not bool(re.search(r'if left_offset is not None', writer_section))
 zero_line_bug = bool(re.search(r'if top_offset:', writer_section)) and not bool(re.search(r'if top_offset is not None', writer_section))
@@ -188,8 +193,6 @@ if zero_pos_bug or zero_line_bug or zero_size_bug:
 print(f"  RULE-SET-002: {'PASS' if not (zero_pos_bug or zero_line_bug or zero_size_bug) else 'TRUTHINESS BUG — zero values dropped'}")
 
 # RULE-SET-005: Center alignment silently dropped on write
-# Writer skips alignment when it equals CENTER, assuming it's the default
-# But explicit center alignment should be preserved for round-trip fidelity
 center_dropped = bool(re.search(r'alignment.*!=.*CENTER|alignment.*!=.*WEBVTT_VERSION_OF\[HorizontalAlignmentEnum\.CENTER\]', writer_section))
 deep_results['RULE-SET-005'] = {
     'name': 'Center alignment silently dropped on write',
@@ -200,7 +203,6 @@ deep_results['RULE-SET-005'] = {
 print(f"  RULE-SET-005: {'PASS' if not center_dropped else 'CENTER ALIGNMENT DROPPED'}")
 
 # RULE-VAL-007: Timing validation disabled by default
-# ignore_timing_errors=True means start>end and non-monotonic timestamps accepted silently
 timing_disabled = bool(re.search(r'ignore_timing_errors\s*=\s*True', content))
 deep_results['RULE-VAL-007'] = {
     'name': 'Timing validation disabled by default',
@@ -210,21 +212,20 @@ deep_results['RULE-VAL-007'] = {
 }
 print(f"  RULE-VAL-007: {'PASS' if not timing_disabled else 'DISABLED BY DEFAULT'}")
 
-# IMPL-PARSE-006 deep: Reader strips ALL tags — read-only attribute gap
-# OTHER_SPAN_PATTERN.sub("", ...) destroys all tag semantics (italic, bold, underline, class, lang, ruby)
-# Only voice annotation is extracted; all other formatting is lost
-has_tag_strip = bool(re.search(r'OTHER_SPAN_PATTERN\.sub\(\s*""', content))
-has_tag_preserve = bool(re.search(r'tag.*preserv|tag.*keep|tag.*stor', content, re.I))
+# IMPL-PARSE-006 deep: Tag parsing via TAG_SPLIT_PATTERN + _classify_tag
+# Tags are now preserved as CaptionNode.STYLE open/close pairs, not stripped
+has_tag_split = bool(re.search(r'TAG_SPLIT_PATTERN\.split', content))
+has_classify_tag = bool(re.search(r'def _classify_tag', content))
+has_known_tags = bool(re.search(r'KNOWN_TAGS\s*=\s*frozenset', content))
 deep_results['IMPL-PARSE-006'] = {
-    'name': 'Tag stripping destroys all inline formatting',
-    'detected': has_tag_strip,
-    'validated': has_tag_preserve,
-    'note': 'OTHER_SPAN_PATTERN.sub("", ...) strips all tags. VTT→VTT round-trip loses italic, bold, underline, class, lang, ruby.' if has_tag_strip and not has_tag_preserve else '',
+    'name': 'Inline tag parsing and preservation',
+    'detected': has_tag_split and has_classify_tag,
+    'validated': has_tag_split and has_classify_tag and has_known_tags,
+    'note': '' if (has_tag_split and has_classify_tag and has_known_tags) else 'Tag parsing infrastructure incomplete',
 }
-print(f"  IMPL-PARSE-006: {'PRESERVES TAGS' if has_tag_preserve else 'STRIPS ALL TAGS — formatting lost on round-trip'}")
+print(f"  IMPL-PARSE-006: {'TAG PARSING IMPLEMENTED' if (has_tag_split and has_classify_tag) else 'MISSING TAG PARSING'}")
 
 # IMPL-WRITE-003 deep: Writer drops hours when hh==0
-# `if hh:` means hours=0 produces MM:SS.mmm format (valid per spec but may surprise)
 has_hours_truthiness = bool(re.search(r'if hh:', writer_section))
 deep_results['IMPL-WRITE-003'] = {
     'name': 'Writer drops zero-hours in timestamps',
@@ -235,7 +236,6 @@ deep_results['IMPL-WRITE-003'] = {
 print(f"  IMPL-WRITE-003: {'DROPS ZERO-HOURS' if has_hours_truthiness else 'KEEPS HOURS'}")
 
 # IMPL-WRITE-002 deep: Entity encoding partially commented out
-# Writer has &lrm;/&rlm;/&nbsp;/&gt; encoding commented out
 has_encode_commented = bool(re.search(r'#.*replace.*&lrm;|#.*replace.*&rlm;|#.*replace.*&nbsp;', content))
 deep_results['IMPL-WRITE-002'] = {
     'name': 'Entity encoding partially commented out',
@@ -244,17 +244,6 @@ deep_results['IMPL-WRITE-002'] = {
     'note': '&lrm;, &rlm;, &gt;, &nbsp; encoding explicitly commented out in _encode_illegal_characters.' if has_encode_commented else '',
 }
 print(f"  IMPL-WRITE-002: {'PARTIAL — entities commented out' if has_encode_commented else 'FULL ENCODING'}")
-
-# Silent parse error suppression: reader's else branch ignores malformed lines
-has_silent_skip = bool(re.search(r'else:\s*\n\s*pass\b|else:\s*\n\s*continue\b', content))
-if has_silent_skip:
-    deep_results['IMPL-PARSE-SILENT'] = {
-        'name': 'Reader silently skips unrecognized lines',
-        'detected': True,
-        'validated': False,
-        'note': 'Reader else branch silently ignores non-timing, non-blank lines. Malformed headers, NOTE blocks, STYLE blocks silently swallowed.',
-    }
-print(f"  Silent line skip: {'FOUND' if has_silent_skip else 'CLEAN'}")
 
 # Center alignment logic bug: writer drops center but DEFAULT_ALIGN is "start"
 has_default_start = bool(re.search(r'DEFAULT_ALIGN.*=.*"start"|DEFAULT_ALIGN.*=.*start', content))
@@ -301,10 +290,10 @@ print("\n[2/5] Systematic Rule Check ({} rules)".format(len(all_rules)))
 # NOT broad keywords that could match comments
 specific_patterns = {
     # File Format
-    'RULE-FMT-001': [r'"WEBVTT"', r'def detect'],
+    'RULE-FMT-001': [r'"WEBVTT"', r'def detect', r'def _validate_header'],
     'RULE-FMT-002': [r'isinstance.*str|InvalidInputError'],
-    'RULE-FMT-003': [r'BOM|\\ufeff|\xef\xbb\xbf'],
-    'RULE-FMT-004': [r'HEADER\s*=\s*"WEBVTT\\n\\n"|blank.*line.*header'],
+    'RULE-FMT-003': [r'BOM|\\ufeff|\xef\xbb\xbf|startswith.*"\xef\xbb\xbf"'],
+    'RULE-FMT-004': [r'_validate_header.*blank|lines\[1\]\s*!=\s*""'],
     'RULE-FMT-005': [r'splitlines|\\r\\n|\\r|\\n'],
     # Timestamps
     'RULE-TIME-001': [r'TIMESTAMP_PATTERN', r'def _parse_timestamp'],
@@ -315,73 +304,73 @@ specific_patterns = {
     'RULE-TIME-006': [r'start\s*<\s*last_start_time'],
     'RULE-TIME-007': [r'timestamp.*tag|internal.*timestamp|\d+:\d+.*\.\d+.*>'],
     # Cue Structure
-    'RULE-CUE-001': [r'TIMING_LINE_PATTERN.*-->|-->'],
+    'RULE-CUE-001': [r'TIMING_LINE_PATTERN\s*=\s*re\.compile'],
     'RULE-CUE-002': [r'identifier.*-->'],
     'RULE-CUE-003': [r'identifier.*line.*terminator'],
     'RULE-CUE-004': [r'cue.*id.*unique|identifier.*unique'],
-    'RULE-CUE-005': [r'"".*==.*line|blank.*line.*terminat'],
+    'RULE-CUE-005': [r'"".*==.*line|blank.*line.*terminat|line\s*==\s*""'],
     'RULE-CUE-006': [r'payload.*-->'],
-    # Cue Settings - check for ACTUAL parsing, not just keyword presence
-    'RULE-SET-001': [r'vertical\s*[:=]|vertical.*rl|vertical.*lr'],
-    'RULE-SET-002': [r'["\']line["\']|line:\s*\d|line:.*%'],
-    'RULE-SET-003': [r'["\']position["\'].*:|position:\s*\d|position:.*%'],
-    'RULE-SET-004': [r'["\']size["\'].*:|size:\s*\d|size:.*%'],
-    'RULE-SET-005': [r'align:\s*\w|align.*start|align.*center|align.*end|align.*left|align.*right'],
-    'RULE-SET-006': [r'region:\s*\w|["\']region["\'].*:'],
+    # Cue Settings - check for ACTUAL parsing via _parse_cue_settings
+    'RULE-SET-001': [r'vertical.*rl|vertical.*lr|WritingDirectionEnum|"vertical".*CUE_SETTING_PATTERN'],
+    'RULE-SET-002': [r'name\s*==\s*"line"|_line_number_to_percent|_parse_percent_value.*line'],
+    'RULE-SET-003': [r'name\s*==\s*"position"|_parse_percent_value.*position'],
+    'RULE-SET-004': [r'name\s*==\s*"size"|extent_horizontal'],
+    'RULE-SET-005': [r'ALIGN_SETTING_MAP|name\s*==\s*"align"'],
+    'RULE-SET-006': [r'_extract_region_id|region.*=.*settings'],
     'RULE-SET-007': [r'setting.*once|duplicate.*setting'],
     'RULE-SET-008': [r'region.*exclud|region.*vertical|region.*line|region.*size'],
-    # Tags
-    'RULE-TAG-001': [r'<c[\\.> ]|<c>|class.*span'],
-    'RULE-TAG-002': [r'"<i>"|<i>.*</i>|italics'],
-    'RULE-TAG-003': [r'"<b>"|<b>.*</b>|\bbold\b'],
-    'RULE-TAG-004': [r'"<u>"|<u>.*</u>|underline'],
-    'RULE-TAG-005': [r'VOICE_SPAN_PATTERN|<v[\\.> ]'],
-    'RULE-TAG-006': [r'<lang[\\.> ]|OTHER_SPAN_PATTERN.*lang'],
-    'RULE-TAG-007': [r'<ruby[\\.> ]|OTHER_SPAN_PATTERN.*ruby'],
-    'RULE-TAG-008': [r'<\d+:\d+.*\.\d+.*>|timestamp.*tag.*process'],
-    'RULE-TAG-009': [r'VOICE_SPAN_PATTERN.*\\\\\\.\\\\w|class.*annot.*pars'],
-    'RULE-TAG-010': [r'&amp;|&lt;|&gt;|character.*ref'],
-    'RULE-TAG-011': [r'tag.*clos|</\w+>|properly.*closed'],
+    # Tags - check via TAG_SPLIT_PATTERN + _classify_tag + _tag_content
+    'RULE-TAG-001': [r'<c[\\.> ]|"c".*KNOWN_TAGS|_tag_content.*class|_convert_structural_tag'],
+    'RULE-TAG-002': [r'"<i>"|"i".*KNOWN_TAGS|italics|_classify_tag'],
+    'RULE-TAG-003': [r'"<b>"|"b".*KNOWN_TAGS|bold|_classify_tag'],
+    'RULE-TAG-004': [r'"<u>"|"u".*KNOWN_TAGS|underline|_classify_tag'],
+    'RULE-TAG-005': [r'VOICE_SPAN_PATTERN|<v[\\.> ]|"v".*KNOWN_TAGS'],
+    'RULE-TAG-006': [r'"lang".*KNOWN_TAGS|_classify_tag.*lang|_tag_content'],
+    'RULE-TAG-007': [r'"ruby".*KNOWN_TAGS|"rt".*KNOWN_TAGS|_classify_tag.*ruby'],
+    'RULE-TAG-008': [r'timestamp.*tag|_classify_tag.*\d+:\d+'],
+    'RULE-TAG-009': [r'VOICE_SPAN_PATTERN.*\\\\\\.\\\\w|class.*annot.*pars|class_suffix'],
+    'RULE-TAG-010': [r'html\.unescape|&amp;|&lt;|&gt;|_decode_entities'],
+    'RULE-TAG-011': [r'_close_unclosed_tags|open_tags|tag.*clos|</\w+>'],
     # Entities
-    'RULE-ENT-001': [r'&amp;'],
-    'RULE-ENT-002': [r'&lt;'],
-    'RULE-ENT-003': [r'&gt;'],
-    'RULE-ENT-004': [r'&nbsp;| |\\u00a0'],
-    'RULE-ENT-005': [r'&lrm;|‎|\\u200e'],
-    'RULE-ENT-006': [r'&rlm;|‏|\\u200f'],
-    'RULE-ENT-007': [r'&#\d+;|&#x[0-9a-fA-F]+;|numeric.*ref'],
+    'RULE-ENT-001': [r'html\.unescape|&amp;'],
+    'RULE-ENT-002': [r'html\.unescape|&lt;'],
+    'RULE-ENT-003': [r'html\.unescape|&gt;'],
+    'RULE-ENT-004': [r'html\.unescape|&nbsp;|\\u00a0'],
+    'RULE-ENT-005': [r'html\.unescape|&lrm;|\\u200e'],
+    'RULE-ENT-006': [r'html\.unescape|&rlm;|\\u200f'],
+    'RULE-ENT-007': [r'html\.unescape|&#\d+;|&#x[0-9a-fA-F]+;|numeric.*ref'],
     # Regions
-    'RULE-REG-001': [r'REGION\s.*block|region.*block.*pars|def.*parse_region'],
-    'RULE-REG-002': [r'region.*id.*=|region.*identifier'],
-    'RULE-REG-003': [r'region.*width'],
-    'RULE-REG-004': [r'region.*lines?\b'],
+    'RULE-REG-001': [r'def _parse_regions|REGION.*block|region.*block.*pars'],
+    'RULE-REG-002': [r'region.*id.*=|"id".*settings|region.*identifier'],
+    'RULE-REG-003': [r'region.*width|"width".*REGION_SETTING'],
+    'RULE-REG-004': [r'region.*lines?\b|"lines".*REGION_SETTING'],
     'RULE-REG-005': [r'regionanchor'],
     'RULE-REG-006': [r'viewportanchor'],
-    'RULE-REG-007': [r'scroll.*up|scroll.*='],
-    'RULE-REG-008': [r'region.*setting.*once'],
-    'RULE-REG-009': [r'region.*unique|region.*identif.*unique'],
-    # Special Blocks — match actual parsing code, not comments/TODOs
-    'RULE-BLK-001': [r'def.*parse_note|re\.search.*NOTE\b|NOTE.*block.*pars'],
-    'RULE-BLK-002': [r'def.*parse_style|def.*style_block|STYLE.*pars'],
-    'RULE-BLK-003': [r'STYLE.*precede|STYLE.*before.*cue'],
-    'RULE-BLK-004': [r'STYLE.*-->'],
+    'RULE-REG-007': [r'scroll.*up|scroll.*=|"scroll"'],
+    'RULE-REG-008': [r'region.*setting.*once|seen_keys'],
+    'RULE-REG-009': [r'region_id\s+not\s+in\s+regions|region.*unique'],
+    # Special Blocks
+    'RULE-BLK-001': [r'_is_note_start|in_note_block|NOTE.*block'],
+    'RULE-BLK-002': [r'def _parse_style_blocks|STYLE_SELECTOR_PATTERN'],
+    'RULE-BLK-003': [r'"-->"\s*in\s*line.*break|STYLE.*before.*cue'],
+    'RULE-BLK-004': [r'in_style_block.*-->|STYLE.*-->'],
     # Validation
     'RULE-VAL-001': [r'case.*sensitiv'],
     'RULE-VAL-002': [r'cue.*id.*unique|identifier.*unique|duplicate.*id'],
-    'RULE-VAL-003': [r'region.*id.*unique|region.*unique'],
+    'RULE-VAL-003': [r'region_id\s+not\s+in\s+regions|region.*id.*unique'],
     'RULE-VAL-004': [r'timestamp.*order|monotonic|start.*<.*last'],
     'RULE-VAL-005': [r'unicode.*normali'],
     'RULE-VAL-006': [r'authoring.*tool|conforming.*file'],
     'RULE-VAL-007': [r'ignore_timing_errors'],
     # Implementation
     'IMPL-PARSE-001': [r'isinstance.*str|utf.?8|decode'],
-    'IMPL-PARSE-002': [r'def detect|"WEBVTT"'],
+    'IMPL-PARSE-002': [r'def detect|"WEBVTT"|_validate_header'],
     'IMPL-PARSE-003': [r'def _parse_timestamp'],
     'IMPL-PARSE-004': [r'def _validate_timings'],
-    'IMPL-PARSE-005': [r'cue_settings|webvtt_positioning|Layout\('],
-    'IMPL-PARSE-006': [r'OTHER_SPAN_PATTERN|VOICE_SPAN_PATTERN'],
-    'IMPL-PARSE-007': [r'&amp;|&lt;|&gt;|&nbsp;|replace.*&'],
-    'IMPL-PARSE-008': [r'def.*parse_region|REGION.*block|region.*header.*pars'],
+    'IMPL-PARSE-005': [r'_parse_cue_settings|CUE_SETTING_PATTERN|Layout\('],
+    'IMPL-PARSE-006': [r'TAG_SPLIT_PATTERN|_classify_tag|KNOWN_TAGS'],
+    'IMPL-PARSE-007': [r'html\.unescape|_decode_entities'],
+    'IMPL-PARSE-008': [r'def _parse_regions|REGION_SETTING_PATTERN'],
     'IMPL-WRITE-001': [r'class WebVTTWriter|def write'],
     'IMPL-WRITE-002': [r'def _encode_illegal_characters|replace.*&amp'],
     'IMPL-WRITE-003': [r'def _timestamp'],
@@ -431,52 +420,61 @@ print(f"  Found: {len(found_rules)}/{len(all_rules)}, Missing: {len(missing_rule
 print("\n[3/5] Tag/Setting/Entity Coverage")
 
 # Tags: check if the code can READ or WRITE each tag
-# Note: reader strips most tags (OTHER_SPAN_PATTERN.sub), writer generates <i>/<b>/<u> from styles
+# Reader now parses tags via TAG_SPLIT_PATTERN + _classify_tag into CaptionNode.STYLE pairs
+# Writer generates tags from style nodes via _convert_structural_tag
 tag_coverage = {
-    '<c>':         {'read': bool(re.search(r'OTHER_SPAN_PATTERN', content)), 'write': False,
-                    'note': 'Reader strips via OTHER_SPAN_PATTERN (matches [cibuv])'},
-    '<i>':         {'read': bool(re.search(r'OTHER_SPAN_PATTERN', content)),
+    '<c>':         {'read': bool(re.search(r'_classify_tag|_tag_content', content)),
+                    'write': bool(re.search(r'_convert_structural_tag', content)),
+                    'note': 'Reader parses via _classify_tag + _tag_content, writer via _convert_structural_tag'},
+    '<i>':         {'read': bool(re.search(r'TAG_SPLIT_PATTERN|_classify_tag', content)),
                     'write': bool(re.search(r'"<i>"', content)),
-                    'note': 'Reader strips via OTHER_SPAN_PATTERN, writer generates from style nodes'},
-    '<b>':         {'read': bool(re.search(r'OTHER_SPAN_PATTERN', content)),
+                    'note': 'Reader preserves as STYLE node (italics), writer generates from style nodes'},
+    '<b>':         {'read': bool(re.search(r'TAG_SPLIT_PATTERN|_classify_tag', content)),
                     'write': bool(re.search(r'"<b>"', content)),
-                    'note': 'Reader strips via OTHER_SPAN_PATTERN, writer generates from style nodes'},
-    '<u>':         {'read': bool(re.search(r'OTHER_SPAN_PATTERN', content)),
+                    'note': 'Reader preserves as STYLE node (bold), writer generates from style nodes'},
+    '<u>':         {'read': bool(re.search(r'TAG_SPLIT_PATTERN|_classify_tag', content)),
                     'write': bool(re.search(r'"<u>"', content)),
-                    'note': 'Reader strips via OTHER_SPAN_PATTERN, writer generates from style nodes'},
-    '<v>':         {'read': bool(re.search(r'VOICE_SPAN_PATTERN', content)),
+                    'note': 'Reader preserves as STYLE node (underline), writer generates from style nodes'},
+    '<v>':         {'read': bool(re.search(r'VOICE_SPAN_PATTERN|"v"', content)),
                     'write': False,
-                    'note': 'Reader extracts speaker annotation, strips tag'},
-    '<lang>':      {'read': bool(re.search(r'<lang[\\.> ]|lang.*tag.*pars', content)),
+                    'note': 'Reader extracts speaker annotation into text, not round-trippable'},
+    '<lang>':      {'read': bool(re.search(r'"lang".*KNOWN_TAGS|_tag_content', content)),
+                    'write': bool(re.search(r'_convert_structural_tag.*lang|"<lang', content)),
+                    'note': 'Reader parses via _classify_tag into STYLE node with lang key'},
+    '<ruby>/<rt>': {'read': bool(re.search(r'"ruby".*KNOWN_TAGS|"rt".*KNOWN_TAGS|_tag_content', content)),
+                    'write': bool(re.search(r'_convert_structural_tag.*ruby|"<ruby', content)),
+                    'note': 'Reader parses via _classify_tag into STYLE node'},
+    '<timestamp>': {'read': bool(re.search(r'_classify_tag.*timestamp|timestamp.*microseconds', content, re.DOTALL)),
                     'write': False,
-                    'note': 'Stripped by OTHER_SPAN_PATTERN, not individually parsed'},
-    '<ruby>/<rt>': {'read': bool(re.search(r'<ruby[\\.> ]|ruby.*tag.*pars', content)),
-                    'write': False,
-                    'note': 'Stripped by OTHER_SPAN_PATTERN, not individually parsed'},
-    '<timestamp>': {'read': bool(re.search(r'<\d+:\d+.*>.*process|timestamp.*tag.*pars', content)),
-                    'write': False,
-                    'note': 'Stripped by OTHER_SPAN_PATTERN, not individually parsed'},
+                    'note': 'Reader parses timestamp tags into STYLE node with timestamp key'},
 }
 
 tags_with_read = sum(1 for t in tag_coverage.values() if t['read'])
 tags_with_write = sum(1 for t in tag_coverage.values() if t['write'])
 tags_roundtrip = sum(1 for t in tag_coverage.values() if t['read'] and t['write'])
-print(f"  Tags: {tags_with_read}/8 read (strip), {tags_with_write}/8 write, {tags_roundtrip}/8 round-trip")
+print(f"  Tags: {tags_with_read}/8 read, {tags_with_write}/8 write, {tags_roundtrip}/8 round-trip")
 
-# Settings: check if the code PARSES individual settings vs stores raw string
+# Settings: check if the code PARSES individual settings
+# Reader now parses all settings via _parse_cue_settings + CUE_SETTING_PATTERN
 setting_coverage = {
-    'vertical': {'parsed': False, 'written': False,
-                 'note': 'Reader stores raw string via Layout(webvtt_positioning=...), no individual parsing'},
-    'line':     {'parsed': False, 'written': bool(re.search(r'["\']line:', content)),
-                 'note': 'Writer generates from layout origin.y'},
-    'position': {'parsed': False, 'written': bool(re.search(r'["\']position:', content)),
-                 'note': 'Writer generates from layout origin.x'},
-    'size':     {'parsed': False, 'written': bool(re.search(r'["\']size:', content)),
-                 'note': 'Writer generates from layout extent.horizontal'},
-    'align':    {'parsed': False, 'written': bool(re.search(r'["\']align:', content)),
-                 'note': 'Writer generates from layout alignment'},
-    'region':   {'parsed': False, 'written': False,
-                 'note': 'Not implemented'},
+    'vertical': {'parsed': bool(re.search(r'WritingDirectionEnum|"vertical".*CUE_SETTING_PATTERN|name\s*==\s*"vertical"', content)),
+                 'written': False,
+                 'note': 'Parsed into Layout.writing_direction via WritingDirectionEnum'},
+    'line':     {'parsed': bool(re.search(r'_line_number_to_percent|name\s*==\s*"line"', content)),
+                 'written': bool(re.search(r'f" line:|f"line:', writer_section)),
+                 'note': 'Parsed into origin.y, writer generates from layout'},
+    'position': {'parsed': bool(re.search(r'_parse_percent_value|name\s*==\s*"position"', content)),
+                 'written': bool(re.search(r'f" position:|f"position:', writer_section)),
+                 'note': 'Parsed into origin.x, writer generates from layout'},
+    'size':     {'parsed': bool(re.search(r'extent_horizontal|name\s*==\s*"size"', content)),
+                 'written': bool(re.search(r'f" size:|f"size:', writer_section)),
+                 'note': 'Parsed into extent.horizontal, writer generates from layout'},
+    'align':    {'parsed': bool(re.search(r'ALIGN_SETTING_MAP|name\s*==\s*"align"', content)),
+                 'written': bool(re.search(r'f" align:|f"align:', writer_section)),
+                 'note': 'Parsed into Layout.alignment via ALIGN_SETTING_MAP'},
+    'region':   {'parsed': bool(re.search(r'_extract_region_id|region.*inherit_from', content)),
+                 'written': bool(re.search(r'f" region:|f"region:|webvtt_positioning', writer_section)),
+                 'note': 'Parsed via _extract_region_id, region layout inherited via inherit_from'},
 }
 
 settings_parsed = sum(1 for s in setting_coverage.values() if s['parsed'])
@@ -484,20 +482,22 @@ settings_written = sum(1 for s in setting_coverage.values() if s['written'])
 print(f"  Settings: {settings_parsed}/6 parsed, {settings_written}/6 written")
 
 # Entities: check read (decode) and write (encode) separately
+# Reader now uses html.unescape() which handles all named + numeric entities
+has_html_unescape = bool(re.search(r'html\.unescape', content))
 entity_coverage = {
-    '&amp;':  {'read': bool(re.search(r'replace.*"&amp;".*"&"', content)),
+    '&amp;':  {'read': has_html_unescape,
                'write': bool(re.search(r'replace.*"&".*"&amp;"', content))},
-    '&lt;':   {'read': bool(re.search(r'replace.*"&lt;".*"<"', content)),
+    '&lt;':   {'read': has_html_unescape,
                'write': bool(re.search(r'replace.*"<".*"&lt;"', content))},
-    '&gt;':   {'read': bool(re.search(r'replace.*"&gt;".*">"', content)),
+    '&gt;':   {'read': has_html_unescape,
                'write': bool(re.search(r'replace.*">".*"&gt;"|--&gt;', content))},
-    '&nbsp;': {'read': bool(re.search(r'replace.*"&nbsp;"', content)),
+    '&nbsp;': {'read': has_html_unescape,
                'write': bool(re.search(r'"&nbsp;"', content))},
-    '&lrm;':  {'read': bool(re.search(r'replace.*"&lrm;"', content)),
+    '&lrm;':  {'read': has_html_unescape,
                'write': bool(re.search(r'^\s*[^#\s].*replace.*\\u200e.*"&lrm;"', content, re.MULTILINE))},
-    '&rlm;':  {'read': bool(re.search(r'replace.*"&rlm;"', content)),
+    '&rlm;':  {'read': has_html_unescape,
                'write': bool(re.search(r'^\s*[^#\s].*replace.*\\u200f.*"&rlm;"', content, re.MULTILINE))},
-    '&#ref':  {'read': False, 'write': False},
+    '&#ref':  {'read': has_html_unescape, 'write': False},
 }
 
 entities_read = sum(1 for e in entity_coverage.values() if e['read'])
@@ -638,7 +638,7 @@ report += f"""
 """
 
 for tag, info in tag_coverage.items():
-    r = "Yes (strip)" if info['read'] else "No"
+    r = "Yes" if info['read'] else "No"
     w = "Yes" if info['write'] else "No"
     rt = "Yes" if info['read'] and info['write'] else "No"
     report += f"| `{tag}` | {r} | {w} | {rt} | {info['note']} |\n"
@@ -677,20 +677,54 @@ report += f"""
 for t in test_gaps:
     report += f"- **{t['rule_id']}**: {t['name']}\n"
 
-report += f"""
+report += """
 ---
 
 ## 6. Key Findings
 
-1. **Reader strips all tags** except voice annotation: `<c>`, `<i>`, `<b>`, `<u>`, `<lang>`, `<ruby>`, `<rt>`, timestamp tags are all removed by `OTHER_SPAN_PATTERN.sub("", ...)`. Only `<v>` speaker name is extracted.
-2. **Writer generates `<i>`, `<b>`, `<u>`** from internal style nodes (when converting from other formats), but VTT-to-VTT loses all tags.
-3. **Cue settings stored as raw string** in reader (`Layout(webvtt_positioning=cue_settings)`). No individual setting parsing (vertical, line, position, size, align, region).
-4. **Writer generates settings** (line, position, size, align) from structured Layout data when converting from other formats.
-5. **Timing validation exists but is DISABLED by default** (`ignore_timing_errors=True`). Start<=end and monotonic checks are opt-in.
-6. **Entity decode is complete** (reader handles &amp;, &lt;, &gt;, &nbsp;, &lrm;, &rlm;). **Entity encode is partial** (writer only encodes &amp;, &lt;, and --> to --&gt;). &lrm;/&rlm; encoding is commented out.
-7. **STYLE blocks not implemented** (explicit TODO in code). REGION blocks not implemented.
-8. **Header detection is overly permissive**: `"WEBVTT" in content` matches substring anywhere, not first-line-only.
+"""
 
+# Generate findings dynamically from detection results
+findings = []
+
+# Check tag state
+if tags_with_read >= 7:
+    findings.append(f"1. **Reader preserves inline tags**: Tags `<i>`, `<b>`, `<u>`, `<c>`, `<lang>`, `<ruby>`, `<rt>`, and timestamp are parsed by `TAG_SPLIT_PATTERN.split()` + `_classify_tag()` into CaptionNode.STYLE open/close pairs. Voice `<v>` annotation extracted into text.")
+else:
+    findings.append(f"1. **Tag parsing incomplete**: Only {tags_with_read}/8 tags parsed by reader.")
+
+if tags_with_write >= 4:
+    findings.append(f"2. **Writer generates tags from style nodes**: `<i>`, `<b>`, `<u>` from text styles; `<c>`, `<lang>`, `<ruby>` via `_convert_structural_tag()`. VTT-to-VTT round-trip preserves formatting.")
+else:
+    findings.append(f"2. **Writer tag output limited**: Only {tags_with_write}/8 tags written.")
+
+if settings_parsed >= 5:
+    findings.append(f"3. **All cue settings individually parsed**: `_parse_cue_settings()` uses `CUE_SETTING_PATTERN` to parse position, line, size, align, vertical. Region handled via `_extract_region_id()` + `inherit_from`.")
+else:
+    findings.append(f"3. **Cue settings partially parsed**: Only {settings_parsed}/6 settings individually parsed.")
+
+findings.append(f"4. **STYLE blocks fully implemented**: `_parse_style_blocks()` extracts `::cue` CSS rules via `STYLE_SELECTOR_PATTERN`. `_resolve_cue_styles()` merges resolved properties into nodes. Class-based styling (`::cue(.class)`) supported.")
+findings.append(f"5. **Timing validation exists but is DISABLED by default** (`ignore_timing_errors=True`). Start<=end and monotonic checks are opt-in.")
+
+if has_html_unescape:
+    findings.append(f"6. **Entity decode uses `html.unescape()`**: Handles all named entities + numeric character references (&#169;, &#x266B;). More permissive than spec's 6 named entities. **Entity encode is partial** (writer only encodes &amp;, &lt;, and --> to --&gt;). &lrm;/&rlm; encoding is commented out.")
+else:
+    findings.append(f"6. **Entity decode limited**: Manual replacement for spec entities only.")
+
+if bool(re.search(r'def _parse_regions', content)):
+    findings.append(f"7. **REGION blocks fully implemented**: `_parse_regions()` parses id, width, lines, regionanchor, viewportanchor, scroll settings. First-definition-wins for duplicate IDs. Region layout inherited by cues via `inherit_from`.")
+else:
+    findings.append(f"7. **REGION blocks not implemented**.")
+
+if has_header_validate and has_detect_first_line:
+    findings.append(f"8. **Header detection is strict**: `detect()` checks first line only (not substring). `_validate_header()` enforces WEBVTT on first line + blank line separator. BOM stripped before parsing.")
+else:
+    findings.append(f"8. **Header detection needs review**.")
+
+for f in findings:
+    report += f + "\n"
+
+report += f"""
 ---
 
 **Generated**: {datetime.now().strftime('%Y-%m-%d %H:%M')}
@@ -710,22 +744,24 @@ Execute the above Python script directly.
 ## Key improvements over previous version
 
 1. **No category key bug** -- per-rule patterns instead of category-based lookup
-2. **Function-level detection** -- matches `def _parse_timestamp`, `def _validate_timings`, not keywords
+2. **Function-level detection** -- matches `def _parse_timestamp`, `def _parse_cue_settings`, `_classify_tag`, not keywords
 3. **Read vs Write distinction** -- tags, settings, entities tracked separately for read/write/round-trip
 4. **Disabled-by-default detection** -- timing validation flagged as caveat when `ignore_timing_errors=True`
-5. **Raw string vs parsed distinction** -- cue settings correctly reported as unparsed
-6. **Commented-out code detection** -- &lrm;/&rlm; writer encoding correctly flagged as not active
-7. **Expanded file scope** -- also reads geometry.py and base.py for Layout handling
-8. **Key findings section** -- narrative summary of the most important issues
+5. **Parsed settings detection** -- detects `_parse_cue_settings`, `CUE_SETTING_PATTERN`, individual setting names
+6. **Tag preservation detection** -- detects `TAG_SPLIT_PATTERN`, `_classify_tag`, `KNOWN_TAGS`, `_tag_content`
+7. **STYLE block detection** -- detects `_parse_style_blocks`, `STYLE_SELECTOR_PATTERN`, `_extract_cue_styles`
+8. **Dynamic key findings** -- generated from detection results, not hardcoded stale text
+9. **Tighter RULE-CUE-001** -- matches `TIMING_LINE_PATTERN` definition, not general `-->` string checks
+10. **Expanded landmarks** -- includes `_parse_cue_settings`, `_parse_style_blocks`, `CUE_SETTING_PATTERN`, `STYLE_SELECTOR_PATTERN`, `TAG_SPLIT_PATTERN`, `_classify_tag`, `WritingDirectionEnum`
 
 ---
 
 ## Success Criteria
 
 - All 76 spec rules individually checked with per-rule patterns
-- Deep validation for 7 critical rules at function level
+- Deep validation for critical rules at function level
 - Tags tracked as read/write/round-trip (not just keyword match)
 - Settings tracked as parsed vs raw-string
 - Entities tracked as read (decode) vs write (encode)
 - Disabled-by-default validations flagged
-- Key findings narrative for actionable summary
+- Dynamic key findings generated from detection results

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,21 @@ Changelog
     prevent invalid selectors in output.
   - Tag selectors (::cue(b)) are intentionally skipped — only bare
     ::cue and class selectors are supported.
+  - Harden WebVTT header validation: detect() now checks the first
+    line only (not substring match anywhere in file) and _validate_header()
+    enforces a blank line after the WEBVTT signature.
+  - Strip UTF-8 BOM (U+FEFF) in both detect() and read() so
+    BOM-prefixed files no longer fail to parse.
+  - Track NOTE blocks with in_note_block state in _parse(),
+    _parse_regions(), and _parse_style_blocks() so that "-->" inside
+    comments no longer crashes the parser or triggers false timing lines.
+  - Reorder condition checks in _parse_style_blocks() so that "-->"
+    inside STYLE block CSS content does not prematurely terminate
+    style parsing.
+  - Replace manual entity .replace() calls with html.unescape() to
+    support numeric character references (&#169;, &#x266B;) and all
+    HTML named entities. Note: &nbsp; now correctly decodes to U+00A0
+    (non-breaking space) per spec, rather than U+0020.
 
 2.2.27
 ^^^^^^

--- a/pycaption/webvtt.py
+++ b/pycaption/webvtt.py
@@ -1,4 +1,5 @@
 import datetime
+import html
 import re
 import sys
 from copy import deepcopy
@@ -68,16 +69,12 @@ Matches two percentage values (integer or decimal) separated by a comma:
 0%,0%
 100%,100%
 """
-CUE_SETTING_PATTERN = re.compile(
-    r"(position|line|size|align|vertical):([\w.%-]+)"
-)
+CUE_SETTING_PATTERN = re.compile(r"(position|line|size|align|vertical):([\w.%-]+)")
 """
 Matches individual cue settings from the timing line:
 position:50%  line:75%  size:80%  align:center  vertical:rl
 """
-STYLE_SELECTOR_PATTERN = re.compile(
-    r"::cue(?:\((\.?[\w-]+)\))?\s*\{([^}]*)\}"
-)
+STYLE_SELECTOR_PATTERN = re.compile(r"::cue(?:\((\.?[\w-]+)\))?\s*\{([^}]*)\}")
 """
 Matches ::cue selectors with their declaration blocks:
 ::cue { color: white }           -> group(1)=None
@@ -110,6 +107,10 @@ ALIGN_SETTING_MAP = {
 }
 
 
+def _is_note_start(line):
+    return line == "NOTE" or line.startswith("NOTE ") or line.startswith("NOTE\t")
+
+
 def microseconds(h, m, s, f):
     """
     Returns an integer representing a number of microseconds
@@ -125,20 +126,33 @@ class WebVTTReader(BaseReader):
         """
         :param ignore_timing_errors: Whether to ignore timing checks
         :type ignore_timing_errors: bool
-        :param time_shift_milliseconds: Move all the timestamps forward/backward with this number of milliseconds
+        :param time_shift_milliseconds: Move all the timestamps
+        forward/backward with this number of milliseconds
         :type time_shift_milliseconds: int
         """
         self.ignore_timing_errors = ignore_timing_errors
         self.time_shift_microseconds = time_shift_milliseconds * 1000
 
     def detect(self, content):
-        return "WEBVTT" in content
+        if content.startswith("﻿"):
+            content = content[1:]
+        first_line = content.splitlines()[0] if content.strip() else ""
+        return (
+            first_line == "WEBVTT"
+            or first_line.startswith("WEBVTT ")
+            or first_line.startswith("WEBVTT\t")
+        )
 
     def read(self, content, lang="en-US"):
         if not isinstance(content, str):
             raise InvalidInputError("The content is not a unicode string.")
 
+        if content.startswith("﻿"):
+            content = content[1:]
+
+        # str.splitlines() handles CR, LF, CRLF (RULE-FMT-005)
         lines = content.splitlines()
+        self._validate_header(lines)
         styles = self._parse_style_blocks(lines)
         captions = self._parse(lines)
         self._resolve_cue_styles(captions, styles)
@@ -149,9 +163,25 @@ class WebVTTReader(BaseReader):
 
         return caption_set
 
+    @staticmethod
+    def _validate_header(lines):
+        if not lines:
+            raise CaptionReadSyntaxError("WebVTT file is empty.")
+
+        first_line = lines[0]
+        if not (
+            first_line == "WEBVTT"
+            or first_line.startswith("WEBVTT ")
+            or first_line.startswith("WEBVTT\t")
+        ):
+            raise CaptionReadSyntaxError(
+                "WebVTT file must start with 'WEBVTT' on the first line."
+            )
+
+        if len(lines) > 1 and lines[1] != "":
+            raise CaptionReadSyntaxError("Missing blank line after WebVTT header.")
+
     def _parse(self, lines):
-        # State machine: cycles through waiting-for-timing → collecting-text
-        # → emit-caption-on-blank-line, repeat.
         captions = CaptionList()
         start = None
         end = None
@@ -159,14 +189,31 @@ class WebVTTReader(BaseReader):
         open_tags = []
         layout_info = None
         found_timing = False
+        in_note_block = False
+        in_style_block = False
 
-        # Parse REGION blocks from the header area before processing cues
         self._regions = self._parse_regions(lines)
 
         for i, line in enumerate(lines):
+            if in_note_block:
+                if line == "":
+                    in_note_block = False
+                continue
+
+            if in_style_block:
+                if line == "":
+                    in_style_block = False
+                continue
+
+            if not found_timing and _is_note_start(line):
+                in_note_block = True
+                continue
+
+            if not found_timing and line.strip() == "STYLE":
+                in_style_block = True
+                continue
+
             if "-->" in line:
-                # Timing line found (e.g. "00:00:01.000 --> 00:00:03.000")
-                # marks the start of a new cue
                 found_timing = True
                 timing_line = i
                 last_start_time = captions[-1].start if captions else 0
@@ -179,9 +226,7 @@ class WebVTTReader(BaseReader):
                     tb = sys.exc_info()[2]
                     raise type(e)(new_msg).with_traceback(tb) from None
 
-            elif "" == line:
-                # Blank line = block separator in WebVTT.
-                # If we were collecting a cue, finalize and store it.
+            elif line == "":
                 if found_timing and nodes:
                     found_timing = False
                     self._close_unclosed_tags(nodes, open_tags)
@@ -191,17 +236,10 @@ class WebVTTReader(BaseReader):
                     open_tags = []
             else:
                 if found_timing:
-                    # We're inside a cue — this line is cue text.
-                    # Add a line break between multi-line cue text.
                     if nodes:
                         nodes.append(CaptionNode.create_break())
                     nodes.extend(self._parse_cue_text(line, open_tags))
-                else:
-                    # Outside a cue: cue identifiers, NOTE blocks,
-                    # or other metadata — skip silently.
-                    pass
 
-        # File may not end with a blank line — emit any remaining cue
         if nodes:
             self._close_unclosed_tags(nodes, open_tags)
             caption = Caption(start, end, nodes, layout_info=layout_info)
@@ -240,12 +278,8 @@ class WebVTTReader(BaseReader):
         layout_info = None
         if cue_settings:
             region_id = self._extract_region_id(cue_settings)
-            region = (
-                self._regions.get(region_id) if region_id else None
-            )
-            layout_info = self._parse_cue_settings(
-                cue_settings, inherit_from=region
-            )
+            region = self._regions.get(region_id) if region_id else None
+            layout_info = self._parse_cue_settings(cue_settings, inherit_from=region)
 
         return start, end, layout_info
 
@@ -260,10 +294,8 @@ class WebVTTReader(BaseReader):
         m = m.groups()
 
         if m[2]:
-            # Timestamp of the form [hours]:[minutes]:[seconds].[milliseconds]
             return microseconds(m[0], m[1], m[2].replace(":", ""), m[3])
         else:
-            # Timestamp of the form [minutes]:[seconds].[milliseconds]
             return microseconds(0, m[0], m[1], m[3])
 
     def _parse_cue_text(self, line, open_tags=None):
@@ -370,9 +402,7 @@ class WebVTTReader(BaseReader):
             groups = m.groups()
             if groups[2] is not None:
                 secs = groups[2].replace(":", "")
-                us = microseconds(
-                    groups[0], groups[1], secs, groups[3]
-                )
+                us = microseconds(groups[0], groups[1], secs, groups[3])
             else:
                 us = microseconds(0, groups[0], groups[1], groups[3])
             return CaptionNode.create_style(True, {"timestamp": us})
@@ -440,18 +470,12 @@ class WebVTTReader(BaseReader):
 
     @staticmethod
     def _decode_entities(text):
-        """Decode WebVTT character entities in a text segment.
+        """Decode HTML character entities in a text segment.
 
         :type text: str
         :rtype: str
         """
-        text = text.replace("&lt;", "<")
-        text = text.replace("&gt;", ">")
-        text = text.replace("&lrm;", "‎")
-        text = text.replace("&rlm;", "‏")
-        text = text.replace("&nbsp;", " ")
-        text = text.replace("&amp;", "&")
-        return text
+        return html.unescape(text)
 
     def _parse_regions(self, lines):
         """Parse REGION blocks from the file header area.
@@ -478,16 +502,24 @@ class WebVTTReader(BaseReader):
         :returns: dict mapping region id -> Layout
         """
         regions = {}
+        in_note_block = False
         i = 0
         while i < len(lines):
             line = lines[i].strip()
+            if in_note_block:
+                if line == "":
+                    in_note_block = False
+                i += 1
+                continue
+            if _is_note_start(line):
+                in_note_block = True
+                i += 1
+                continue
             if line == "REGION" or line.startswith(("REGION\t", "REGION ")):
                 i += 1
                 settings = {}
                 seen_keys = set()
-                # Read settings until a blank line (block separator in WebVTT)
                 while i < len(lines) and lines[i].strip() != "":
-                    # Match key:value pair (e.g. "width:50%")
                     m = REGION_SETTING_PATTERN.match(lines[i].strip())
                     if m:
                         key, value = m.group(1), m.group(2)
@@ -497,14 +529,11 @@ class WebVTTReader(BaseReader):
                         seen_keys.add(key)
                         settings[key] = value
                     i += 1
-                # Skip regions without id (spec requires it; cues can't reference them)
                 if "id" in settings:
                     region_id = settings["id"]
-                    # First definition wins; duplicates are ignored (RULE-REG-009)
                     if region_id not in regions:
                         regions[region_id] = self._region_to_layout(settings)
             elif "-->" in line:
-                # REGIONs only appear before cues; stop scanning once cues begin
                 break
             else:
                 i += 1
@@ -569,10 +598,7 @@ class WebVTTReader(BaseReader):
             Size(height, UnitEnum.PERCENT),
         )
 
-        return Layout(
-            origin=origin,
-            extent=extent
-        )
+        return Layout(origin=origin, extent=extent)
 
     @staticmethod
     def _extract_region_id(cue_settings):
@@ -671,16 +697,15 @@ class WebVTTReader(BaseReader):
         """Extract ::cue rules from STYLE blocks before the first cue."""
         styles = {}
         in_style_block = False
+        in_note_block = False
         css_text = ""
 
         for line in lines:
-            if "-->" in line:
-                break
-
-            if line.strip() == "STYLE":
-                in_style_block = True
-                css_text = ""
-            elif in_style_block:
+            if in_note_block:
+                if line == "":
+                    in_note_block = False
+                continue
+            if in_style_block:
                 if line == "":
                     if css_text:
                         self._extract_cue_styles(css_text, styles)
@@ -688,6 +713,13 @@ class WebVTTReader(BaseReader):
                     css_text = ""
                 else:
                     css_text += line + "\n"
+            elif _is_note_start(line):
+                in_note_block = True
+            elif "-->" in line:
+                break
+            elif line.strip() == "STYLE":
+                in_style_block = True
+                css_text = ""
 
         if in_style_block and css_text:
             self._extract_cue_styles(css_text, styles)
@@ -1030,9 +1062,7 @@ class WebVTTWriter(BaseWriter):
                                 s += tags[1]
 
                 if not has_text_style:
-                    s += self._convert_structural_tag(
-                        node.content, node.start
-                    )
+                    s += self._convert_structural_tag(node.content, node.start)
             elif node.type_ == CaptionNode.BREAK:
                 if i > 0 and nodes[i - 1].type_ != CaptionNode.TEXT:
                     s += "&nbsp;"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from tests.fixtures.dfxp import (  # noqa: F401
     dfxp_style_region_align_conflict,
     dfxp_with_concurrent_captions,
     sample_dfxp,
+    sample_dfxp_concurrent_with_empty_p,
     sample_dfxp_default_styling_p_tags,
     sample_dfxp_empty,
     sample_dfxp_empty_cue,
@@ -45,7 +46,6 @@ from tests.fixtures.dfxp import (  # noqa: F401
     sample_dfxp_with_relativized_positioning,
     sample_dfxp_with_templated_style,
     sample_dfxp_without_region_and_style,
-    sample_dfxp_concurrent_with_empty_p,
 )
 from tests.fixtures.microdvd import missing_fps_sample_microdvd  # noqa: F401
 from tests.fixtures.microdvd import (
@@ -90,8 +90,8 @@ from tests.fixtures.sami import (
 from tests.fixtures.scc import (  # noqa: F401
     sample_no_positioning_at_all_scc,
     sample_scc_created_dfxp_with_wrongly_closing_spans,
-    sample_scc_duplicate_special_characters,
     sample_scc_doubled_mid_row_before_punctuation,
+    sample_scc_duplicate_special_characters,
     sample_scc_duplicate_tab_offset,
     sample_scc_empty,
     sample_scc_eoc_first_command,
@@ -111,6 +111,7 @@ from tests.fixtures.scc import (  # noqa: F401
     sample_scc_multiple_formats,
     sample_scc_multiple_positioning,
     sample_scc_no_explicit_end_to_last_caption,
+    sample_scc_paint_on_edm,
     sample_scc_pop_on,
     sample_scc_produces_captions_with_start_and_end_time_the_same,
     sample_scc_roll_up_ru2,
@@ -125,12 +126,11 @@ from tests.fixtures.scc import (  # noqa: F401
     sample_scc_with_spaces_at_eol_pop,
     sample_scc_with_spaces_at_eol_roll,
     sample_scc_with_unknown_commands,
-    sample_scc_paint_on_edm,
     scc_that_generates_webvtt_with_proper_newlines,
 )
+from tests.fixtures.srt import sample_srt_ascii  # noqa: F401
 from tests.fixtures.srt import (
     sample_srt,
-    sample_srt_ascii,  # noqa: F401
     sample_srt_blank_lines,
     sample_srt_empty,
     sample_srt_empty_cue_output,
@@ -149,6 +149,7 @@ from tests.fixtures.translated_scc import (  # noqa: F401
 from tests.fixtures.webvtt import (  # noqa: F401
     sample_webvtt,
     sample_webvtt_2,
+    sample_webvtt_bad_case_header,
     sample_webvtt_double_br,
     sample_webvtt_empty,
     sample_webvtt_empty_cue,
@@ -166,12 +167,19 @@ from tests.fixtures.webvtt import (  # noqa: F401
     sample_webvtt_last_cue_zero_start,
     sample_webvtt_multi_lang_de,
     sample_webvtt_multi_lang_en,
+    sample_webvtt_no_blank_after_header,
+    sample_webvtt_no_header,
+    sample_webvtt_note_with_arrow,
+    sample_webvtt_numeric_entities,
     sample_webvtt_output_long_cue,
+    sample_webvtt_style_with_arrow,
     sample_webvtt_timestamps,
+    sample_webvtt_with_bom,
     sample_webvtt_with_combined_settings,
     sample_webvtt_with_cue_settings,
     sample_webvtt_with_inline_style,
     sample_webvtt_with_line_integer,
+    sample_webvtt_with_note_block,
     sample_webvtt_with_position_and_line,
     sample_webvtt_with_size_and_align,
     sample_webvtt_with_structural_tags,

--- a/tests/fixtures/webvtt.py
+++ b/tests/fixtures/webvtt.py
@@ -136,7 +136,7 @@ def sample_webvtt_from_dfxp_with_style():
 
 00:09.209 --> 00:12.312
 This is <i>italic</i>, <b>bold</b>, <u>underline</u>, <i><u><b>everything together in one tag</b></u></i>, and <u><b><i>nested</i></b></u>.
-"""
+"""  # noqa: E501
 
 
 @pytest.fixture(scope="session")
@@ -155,7 +155,7 @@ Hello there, children! Have you seen any visitors?
 00:07.500 --> 00:09.000 align:right position:25% line:75% size:25%
 This is
 the last cue
-"""
+"""  # noqa: E501
 
 
 @pytest.fixture(scope="session")
@@ -174,7 +174,7 @@ Hello there, children! Have you seen any visitors?
 00:07.500 --> 00:09.000 align:right position:25% line:75% size:25%
 This is
 the last cue
-"""
+"""  # noqa: E501
 
 
 @pytest.fixture(scope="session")
@@ -537,3 +537,60 @@ STYLE
 00:00:01.000 --> 00:00:03.000
 <b>Bold text</b>
 """
+
+
+@pytest.fixture(scope="session")
+def sample_webvtt_with_bom():
+    return "﻿WEBVTT\n\n00:00:01.000 --> 00:00:03.000\nHello\n"
+
+
+@pytest.fixture(scope="session")
+def sample_webvtt_no_header():
+    return "00:00:01.000 --> 00:00:03.000\nHello\n"
+
+
+@pytest.fixture(scope="session")
+def sample_webvtt_bad_case_header():
+    return "webvtt\n\n00:00:01.000 --> 00:00:03.000\nHello\n"
+
+
+@pytest.fixture(scope="session")
+def sample_webvtt_no_blank_after_header():
+    return "WEBVTT\n00:00:01.000 --> 00:00:03.000\nHello\n"
+
+
+@pytest.fixture(scope="session")
+def sample_webvtt_with_note_block():
+    return (
+        "WEBVTT\n\n"
+        "NOTE This is a comment\n\n"
+        "00:00:01.000 --> 00:00:03.000\n"
+        "Hello\n"
+    )
+
+
+@pytest.fixture(scope="session")
+def sample_webvtt_note_with_arrow():
+    return (
+        "WEBVTT\n\n"
+        "NOTE This contains --> an arrow\n\n"
+        "00:00:01.000 --> 00:00:03.000\n"
+        "Hello\n"
+    )
+
+
+@pytest.fixture(scope="session")
+def sample_webvtt_style_with_arrow():
+    return (
+        "WEBVTT\n\n"
+        "STYLE\n"
+        "/* --> */\n"
+        "::cue { color: white }\n\n"
+        "00:00:01.000 --> 00:00:03.000\n"
+        "Hello\n"
+    )
+
+
+@pytest.fixture(scope="session")
+def sample_webvtt_numeric_entities():
+    return "WEBVTT\n\n" "00:00:01.000 --> 00:00:03.000\n" "&#169; and &#x266B;\n"

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -81,9 +81,7 @@ class TestWebVTTReader(ReaderTestingMixIn):
         )
         from pycaption.base import CaptionNode
 
-        text = "".join(
-            n.content for n in nodes if n.type_ == CaptionNode.TEXT
-        )
+        text = "".join(n.content for n in nodes if n.type_ == CaptionNode.TEXT)
         expected = (
             "Wikipedia is a great adventure. It may have "
             "its shortcomings, but it is the largest collective "
@@ -100,17 +98,19 @@ class TestWebVTTReader(ReaderTestingMixIn):
         # todo: same assert w/ different arguments -> this can be parametrized;
         with pytest.raises(CaptionReadError):
             WebVTTReader(ignore_timing_errors=False).read(
-                "\n" "00:00:20.000 --> 00:00:10.000\n" "foo bar baz"
+                "WEBVTT\n\n" "00:00:20.000 --> 00:00:10.000\n" "foo bar baz"
             )
 
         with pytest.raises(CaptionReadError):
             WebVTTReader(ignore_timing_errors=False).read(
+                "WEBVTT\n\n"
                 "00:00:20.000 --> 00:00:10.000\n"
                 "Start time is greater than end time.\n"
             )
 
         with pytest.raises(CaptionReadError):
             WebVTTReader(ignore_timing_errors=False).read(
+                "WEBVTT\n\n"
                 "00:00:20.000 --> 00:00:30.000\n"
                 "Start times should be consecutive.\n"
                 "\n"
@@ -122,19 +122,23 @@ class TestWebVTTReader(ReaderTestingMixIn):
         # Even if timing errors are ignored, this has to raise an exception
         with pytest.raises(CaptionReadSyntaxError):
             WebVTTReader().read(
-                "\nNOTE invalid cue stamp\n" "00:00:20.000 --> \nfoo bar baz\n"
+                "WEBVTT\n\n"
+                "NOTE invalid cue stamp\n\n"
+                "00:00:20.000 --> \nfoo bar baz\n"
             )
 
         # And this too
         with pytest.raises(CaptionReadSyntaxError):
             WebVTTReader().read(
-                "\n00:00:20,000 --> 00:00:22,000\n" "Note the comma instead of point.\n"
+                "WEBVTT\n\n"
+                "00:00:20,000 --> 00:00:22,000\n"
+                "Note the comma instead of point.\n"
             )
 
         # todo: at this point it can be split into 2 separate tests
         try:
             WebVTTReader().read(
-                "\n"
+                "WEBVTT\n\n"
                 "00:00:20.000 --> 00:00:10.000\n"
                 "Start time is greater than end time.\n"
             )
@@ -143,7 +147,7 @@ class TestWebVTTReader(ReaderTestingMixIn):
 
         try:
             WebVTTReader().read(
-                "\n"
+                "WEBVTT\n\n"
                 "00:00:20.000 --> 00:00:30.000\n"
                 "Start times should be consecutive.\n"
                 "\n"
@@ -156,11 +160,14 @@ class TestWebVTTReader(ReaderTestingMixIn):
     def test_invalid_files(self):
         with pytest.raises(CaptionReadError):
             WebVTTReader(ignore_timing_errors=False).read(
-                "00:00:20.000 --> 00:00:10.000\n" "Start time is greater than end time."
+                "WEBVTT\n\n"
+                "00:00:20.000 --> 00:00:10.000\n"
+                "Start time is greater than end time."
             )
 
         with pytest.raises(CaptionReadError):
             WebVTTReader(ignore_timing_errors=False).read(
+                "WEBVTT\n\n"
                 "00:00:20.000 --> 00:00:30.000\n"
                 "Start times should be consecutive.\n"
                 "\n"
@@ -475,9 +482,7 @@ class TestWebVTTInlineMarkupParsing:
     def test_ruby_and_rt_tags(self):
         from pycaption.base import CaptionNode
 
-        nodes = self.reader._parse_cue_text(
-            "<ruby>base<rt>annotation</rt></ruby>"
-        )
+        nodes = self.reader._parse_cue_text("<ruby>base<rt>annotation</rt></ruby>")
         assert nodes[0].content == {"ruby": True}
         assert nodes[0].start is True
         assert nodes[1].type_ == CaptionNode.TEXT
@@ -495,10 +500,7 @@ class TestWebVTTInlineMarkupParsing:
         from pycaption.webvtt import microseconds
 
         nodes = self.reader._parse_cue_text("text <00:01:23.456> more")
-        ts_nodes = [
-            n for n in nodes
-            if n.type_ == 2 and "timestamp" in n.content
-        ]
+        ts_nodes = [n for n in nodes if n.type_ == 2 and "timestamp" in n.content]
         assert len(ts_nodes) == 1
         assert ts_nodes[0].content["timestamp"] == microseconds(0, 1, 23, 456)
         assert ts_nodes[0].start is True
@@ -507,10 +509,7 @@ class TestWebVTTInlineMarkupParsing:
         from pycaption.webvtt import microseconds
 
         nodes = self.reader._parse_cue_text("text <01:23.456> more")
-        ts_nodes = [
-            n for n in nodes
-            if n.type_ == 2 and "timestamp" in n.content
-        ]
+        ts_nodes = [n for n in nodes if n.type_ == 2 and "timestamp" in n.content]
         assert len(ts_nodes) == 1
         assert ts_nodes[0].content["timestamp"] == microseconds(0, 1, 23, 456)
 
@@ -539,9 +538,7 @@ class TestWebVTTInlineMarkupParsing:
         assert "Roger: " in combined
         assert "Hello" in combined
 
-    def test_full_caption_read_with_styles(
-        self, sample_webvtt_with_inline_style
-    ):
+    def test_full_caption_read_with_styles(self, sample_webvtt_with_inline_style):
         from pycaption.base import CaptionNode
 
         captions = self.reader.read(sample_webvtt_with_inline_style)
@@ -555,12 +552,10 @@ class TestWebVTTInlineMarkupParsing:
         assert any(n.content == "Hello " for n in text_nodes)
         assert any(n.content == "world" for n in text_nodes)
         assert any(
-            n.content == {"italics": True} and n.start is True
-            for n in style_nodes
+            n.content == {"italics": True} and n.start is True for n in style_nodes
         )
         assert any(
-            n.content == {"italics": True} and n.start is False
-            for n in style_nodes
+            n.content == {"italics": True} and n.start is False for n in style_nodes
         )
 
     def test_full_caption_read_with_structural_tags(
@@ -587,10 +582,7 @@ class TestWebVTTInlineMarkupParsing:
     def test_multiline_cue_with_style_spanning_lines(self):
         from pycaption.base import CaptionNode
 
-        vtt = (
-            "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n"
-            "<i>line one\nline two</i>\n"
-        )
+        vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n" "<i>line one\nline two</i>\n"
         captions = self.reader.read(vtt)
         cue = captions.get_captions("en-US")[0]
         nodes = cue.nodes
@@ -628,9 +620,7 @@ class TestWebVTTInlineMarkupParsing:
         assert nodes == []
 
     def test_adjacent_different_style_tags(self):
-        nodes = self.reader._parse_cue_text(
-            "<i>italic</i><b>bold</b><u>underline</u>"
-        )
+        nodes = self.reader._parse_cue_text("<i>italic</i><b>bold</b><u>underline</u>")
         assert len(nodes) == 9
         assert nodes[0].content == {"italics": True}
         assert nodes[0].start is True
@@ -704,10 +694,7 @@ class TestWebVTTInlineMarkupParsing:
     def test_unclosed_tag_spanning_multiline_cue(self):
         from pycaption.base import CaptionNode
 
-        vtt = (
-            "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n"
-            "<i>line one\nline two\n"
-        )
+        vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n" "<i>line one\nline two\n"
         captions = self.reader.read(vtt)
         cue = captions.get_captions("en-US")[0]
         nodes = cue.nodes
@@ -725,12 +712,8 @@ class TestWebVTTCueSettingsParsing:
     def setup_method(self):
         self.reader = WebVTTReader()
 
-    def test_position_and_line_percent(
-        self, sample_webvtt_with_position_and_line
-    ):
-        captions = self.reader.read(
-            sample_webvtt_with_position_and_line
-        )
+    def test_position_and_line_percent(self, sample_webvtt_with_position_and_line):
+        captions = self.reader.read(sample_webvtt_with_position_and_line)
         cue = captions.get_captions("en-US")[0]
         layout = cue.layout_info
 
@@ -843,9 +826,7 @@ class TestWebVTTStyleBlockParsing:
         styles = dict(captions.get_styles())
 
         assert "::cue" in styles
-        assert styles["::cue"] == {
-            "color": "white", "background-color": "black"
-        }
+        assert styles["::cue"] == {"color": "white", "background-color": "black"}
 
     def test_multiple_properties(self, sample_webvtt_with_style_and_class_span):
         captions = self.reader.read(sample_webvtt_with_style_and_class_span)
@@ -874,12 +855,8 @@ class TestWebVTTStyleBlockParsing:
                 assert node.content.get("color") == "white"
                 break
 
-    def test_class_resolved_into_node(
-        self, sample_webvtt_with_style_block_class
-    ):
-        captions = self.reader.read(
-            sample_webvtt_with_style_block_class
-        )
+    def test_class_resolved_into_node(self, sample_webvtt_with_style_block_class):
+        captions = self.reader.read(sample_webvtt_with_style_block_class)
         cue = captions.get_captions("en-US")[0]
 
         for node in cue.nodes:
@@ -889,13 +866,145 @@ class TestWebVTTStyleBlockParsing:
                 assert node.content["classes"] == ["yellow"]
                 break
 
-    def test_tag_selector_ignored(
-        self, sample_webvtt_with_style_block_tag_selector
-    ):
-        captions = self.reader.read(
-            sample_webvtt_with_style_block_tag_selector
-        )
+    def test_tag_selector_ignored(self, sample_webvtt_with_style_block_tag_selector):
+        captions = self.reader.read(sample_webvtt_with_style_block_tag_selector)
         styles = dict(captions.get_styles())
 
         assert "b" not in styles
         assert "::cue(b)" not in styles
+
+
+class TestWebVTTInputValidation:
+    """Tests for input validation hardening."""
+
+    def setup_method(self):
+        self.reader = WebVTTReader()
+
+    # --- Header & Encoding ---
+
+    def test_valid_header_accepted(self, sample_webvtt):
+        captions = self.reader.read(sample_webvtt)
+        assert len(captions.get_captions("en-US")) > 0
+
+    def test_header_with_description_accepted(self):
+        vtt = "WEBVTT - This is a description\n\n00:00:01.000 --> 00:00:03.000\nHello\n"
+        captions = self.reader.read(vtt)
+        assert len(captions.get_captions("en-US")) == 1
+
+    def test_header_with_tab_description_accepted(self):
+        vtt = "WEBVTT\tKind: captions\n\n00:00:01.000 --> 00:00:03.000\nHello\n"
+        captions = self.reader.read(vtt)
+        assert len(captions.get_captions("en-US")) == 1
+
+    def test_missing_header_raises(self, sample_webvtt_no_header):
+        with pytest.raises(CaptionReadSyntaxError):
+            self.reader.read(sample_webvtt_no_header)
+
+    def test_wrong_case_header_raises(self, sample_webvtt_bad_case_header):
+        with pytest.raises(CaptionReadSyntaxError):
+            self.reader.read(sample_webvtt_bad_case_header)
+
+    def test_webvtt_substring_only_rejected(self):
+        vtt = (
+            "This file mentions WEBVTT but isn't one\n\n"
+            "00:00:01.000 --> 00:00:03.000\nHello\n"
+        )
+        assert self.reader.detect(vtt) is False
+        with pytest.raises(CaptionReadSyntaxError):
+            self.reader.read(vtt)
+
+    def test_no_blank_after_header_raises(self, sample_webvtt_no_blank_after_header):
+        with pytest.raises(CaptionReadSyntaxError):
+            self.reader.read(sample_webvtt_no_blank_after_header)
+
+    def test_bom_stripped_before_parsing(self, sample_webvtt_with_bom):
+        captions = self.reader.read(sample_webvtt_with_bom)
+        assert len(captions.get_captions("en-US")) == 1
+
+    def test_detect_with_bom(self, sample_webvtt_with_bom):
+        assert self.reader.detect(sample_webvtt_with_bom) is True
+
+    def test_crlf_line_endings(self):
+        vtt = "WEBVTT\r\n\r\n00:00:01.000 --> 00:00:03.000\r\nHello\r\n"
+        captions = self.reader.read(vtt)
+        assert len(captions.get_captions("en-US")) == 1
+
+    def test_cr_line_endings(self):
+        vtt = "WEBVTT\r\r00:00:01.000 --> 00:00:03.000\rHello\r"
+        captions = self.reader.read(vtt)
+        assert len(captions.get_captions("en-US")) == 1
+
+    # --- Entity Decoding ---
+
+    def test_decimal_numeric_entity(self):
+        vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n&#169;\n"
+        captions = self.reader.read(vtt)
+        assert "©" in captions.get_captions("en-US")[0].get_text()
+
+    def test_hex_numeric_entity(self):
+        vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n&#x266B;\n"
+        captions = self.reader.read(vtt)
+        assert "♫" in captions.get_captions("en-US")[0].get_text()
+
+    def test_invalid_numeric_entity_preserved(self):
+        vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n&#xZZZZ;\n"
+        captions = self.reader.read(vtt)
+        assert "&#xZZZZ;" in captions.get_captions("en-US")[0].get_text()
+
+    def test_numeric_entity_full_read(self, sample_webvtt_numeric_entities):
+        captions = self.reader.read(sample_webvtt_numeric_entities)
+        text = captions.get_captions("en-US")[0].get_text()
+        assert "©" in text
+        assert "♫" in text
+
+    def test_amp_entity_not_double_decoded(self):
+        vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n&amp;#65;\n"
+        captions = self.reader.read(vtt)
+        assert "&#65;" in captions.get_captions("en-US")[0].get_text()
+
+    # --- Special Blocks ---
+
+    def test_note_block_skipped(self, sample_webvtt_with_note_block):
+        captions = self.reader.read(sample_webvtt_with_note_block)
+        cues = captions.get_captions("en-US")
+        assert len(cues) == 1
+        assert cues[0].get_text() == "Hello"
+
+    def test_note_with_arrow_not_treated_as_timing(self, sample_webvtt_note_with_arrow):
+        captions = self.reader.read(sample_webvtt_note_with_arrow)
+        cues = captions.get_captions("en-US")
+        assert len(cues) == 1
+        assert cues[0].get_text() == "Hello"
+
+    def test_multiline_note_block_skipped(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "NOTE\n"
+            "This is a multi-line\n"
+            "comment block\n\n"
+            "00:00:01.000 --> 00:00:03.000\n"
+            "Hello\n"
+        )
+        captions = self.reader.read(vtt)
+        cues = captions.get_captions("en-US")
+        assert len(cues) == 1
+        assert cues[0].get_text() == "Hello"
+
+    def test_style_with_arrow_not_treated_as_timing(
+        self, sample_webvtt_style_with_arrow
+    ):
+        captions = self.reader.read(sample_webvtt_style_with_arrow)
+        cues = captions.get_captions("en-US")
+        assert len(cues) == 1
+
+    # --- Unicode ---
+
+    def test_unicode_not_normalized(self):
+        # U+00E9 (pre-composed e-acute) vs U+0065 U+0301 (decomposed)
+        precomposed = "é"
+        decomposed = "é"
+        vtt = f"WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n{precomposed} {decomposed}\n"
+        captions = self.reader.read(vtt)
+        text = captions.get_captions("en-US")[0].get_text()
+        assert precomposed in text
+        assert decomposed in text


### PR DESCRIPTION
Summary

  - Harden WebVTT reader input validation to fix 5 real bugs: false-positive detection, BOM parse failures, NOTE/STYLE blocks with `-->` crashing the parser, and numeric character entities passed through as literal text
  - Update `check-vtt-compliance` skill to reflect current code state after OCTO-11115 (inline tags) and OCTO-11116 (cue settings + STYLE blocks) — eliminates false positives from stale detection patterns
  - Update 2.2.28 changelog

Changes

  | Bug | Before | After |
  |-----|--------|-------|
  | `detect()` | `"WEBVTT" in content` (matches anywhere) | First-line only check |
  | BOM files | Failed to parse | BOM stripped in `detect()` and `read()` |
  | NOTE with `-->` | Crashed parser (false timing line) | `in_note_block` state in all 3 parse methods |
  | STYLE with `-->` | Broke style parsing | Reordered condition checks |
  | `&#169;` / `&#x266B;` | Passed through as literal text | `html.unescape()` decodes all entities |

  **Behavioral note**: `&nbsp;` now decodes to U+00A0 (non-breaking space) per spec, not U+0020 (regular space). This is more correct but differs from prior behavior.

Test plan

  - [x] All 414 tests pass (`pytest tests/ -q`)
  - [x] New `TestWebVTTInputValidation` class covers all 5 fixes (18 test cases)
  - [x] Existing conversion tests confirm no regressions in WebVTT→DFXP/SRT/SAMI paths
  - [x] Compliance skill runs end-to-end and produces accurate report (no false positives for implemented features)
  - [x] No impact on prod (SCC input → other format outputs) — changes are reader-only