### PR TITLE
 OCTO-11562 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,8 +28,18 @@ Changelog
 
   - WebVTT reader: parse position and line alignment sub-values
     (``position:50%,line-left``, ``line:80%,center``). The alignment
-    qualifier is now stored in ``Layout`` instead of being silently
-    discarded.
+    qualifier is now stored in ``Layout.position_alignment`` instead of
+    being silently discarded.
+
+  - Fix incorrect origin when converting VTT cues with position
+    alignment ``center`` or ``line-right``/``end`` to DFXP or SCC.
+    Previously the position percentage was stored directly as origin.x,
+    which is only correct for ``line-left``/``start``. For example,
+    ``position:50%,center`` with ``size:60%`` now correctly produces
+    ``origin.x = 20%`` (50% − 60%/2) instead of the wrong ``50%``.
+    ``fit_to_screen()`` resolves the alignment before computing the
+    output region; the result is clamped to 0% so negative origins
+    cannot occur.
 
   - SCC reader: reject timecodes with frame numbers >= 30. Previously
     the parser silently divided the out-of-range value by 30, producing

--- a/pycaption/geometry.py
+++ b/pycaption/geometry.py
@@ -13,6 +13,8 @@ from functools import total_ordering
 
 from .exceptions import CaptionReadSyntaxError, RelativizationError
 
+_UNIT_MISMATCH_MSG = "The sizes should have the same measure units."
+
 
 class UnitEnum(Enum):
     """Enumeration-like object, specifying the units of measure for length
@@ -57,6 +59,15 @@ class HorizontalAlignmentEnum(Enum):
     END = "end"
 
 
+class PositionAlignmentEnum(Enum):
+    """WebVTT position alignment: which edge of the cue box the position
+    percentage anchors to."""
+
+    LINE_LEFT = "line-left"
+    CENTER = "center"
+    LINE_RIGHT = "line-right"
+
+
 class WritingDirectionEnum(Enum):
     """Specifies WebVTT writing direction (vertical cue setting)."""
 
@@ -81,12 +92,12 @@ class Alignment:
         "after": VerticalAlignmentEnum.BOTTOM,
     }
 
-    def __init__(self, horizontal, vertical):
+    def __init__(self, horizontal=None, vertical=None):
         """
-        :type horizontal: HorizontalAlignmentEnum
-        :param horizontal: HorizontalAlignmentEnum member
-        :type vertical: VerticalAlignmentEnum
-        :param vertical: VerticalAlignmentEnum member
+        :type horizontal: HorizontalAlignmentEnum | None
+        :param horizontal: HorizontalAlignmentEnum member, or None
+        :type vertical: VerticalAlignmentEnum | None
+        :param vertical: VerticalAlignmentEnum member, or None
         """
         self.horizontal = horizontal
         self.vertical = vertical
@@ -94,13 +105,15 @@ class Alignment:
     def __hash__(self):
         return hash(hash(self.horizontal) * 83 + hash(self.vertical) * 89 + 97)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Alignment):
             return NotImplemented
         return self.horizontal == other.horizontal and self.vertical == other.vertical
 
     def __repr__(self):
-        return f"<Alignment ({self.horizontal} {self.vertical})>"
+        h = self.horizontal.value if self.horizontal else "None"
+        v = self.vertical.value if self.vertical else "None"
+        return f"<Alignment ({h} {v})>"
 
     def serialized(self):
         """Returns a tuple of the useful information regarding this object"""
@@ -120,11 +133,14 @@ class Alignment:
 
         if not horizontal_obj and not vertical_obj:
             return None
-        return cls(horizontal_obj, vertical_obj)
+        return Alignment(horizontal_obj, vertical_obj)
 
 
 class TwoDimensionalObject:
     """Adds a couple useful methods to its subclasses, nothing fancy."""
+
+    def __init__(self, first, second):
+        raise NotImplementedError
 
     @classmethod
     def from_xml_attribute(cls, attribute):
@@ -133,11 +149,11 @@ class TwoDimensionalObject:
 
         :type attribute: str
         """
-        horizontal, vertical = attribute.split(" ")
-        horizontal = Size.from_string(horizontal)
-        vertical = Size.from_string(vertical)
+        first, second = attribute.split(" ")
+        first = Size.from_string(first)
+        second = Size.from_string(second)
 
-        return cls(horizontal, vertical)
+        return cls(first, second)
 
 
 class Stretch(TwoDimensionalObject):
@@ -177,7 +193,7 @@ class Stretch(TwoDimensionalObject):
             None if not self.vertical else self.vertical.serialized(),
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Stretch):
             return NotImplemented
         return self.horizontal == other.horizontal and self.vertical == other.vertical
@@ -276,7 +292,7 @@ class Point(TwoDimensionalObject):
             None if not self.y else self.y.serialized(),
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Point):
             return NotImplemented
         return self.x == other.x and self.y == other.y
@@ -316,7 +332,7 @@ class Size:
         if self.unit == other.unit:
             return Size(self.value - other.value, self.unit)
         else:
-            raise ValueError("The sizes should have the same measure units.")
+            raise ValueError(_UNIT_MISMATCH_MSG)
 
     def __abs__(self):
         return Size(abs(self.value), self.unit)
@@ -325,14 +341,14 @@ class Size:
         if not isinstance(other, Size):
             return NotImplemented
         if self.unit != other.unit:
-            raise ValueError("The sizes should have the same measure units.")
+            raise ValueError(_UNIT_MISMATCH_MSG)
         return self.value < other.value
 
     def __add__(self, other):
         if self.unit == other.unit:
             return Size(self.value + other.value, self.unit)
         else:
-            raise ValueError("The sizes should have the same measure units.")
+            raise ValueError(_UNIT_MISMATCH_MSG)
 
     def is_relative(self):
         """
@@ -434,7 +450,7 @@ class Size:
         """Returns the "useful" values of this object"""
         return self.value, self.unit
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, Size):
             return NotImplemented
         return self.value == other.value and self.unit == other.unit
@@ -513,11 +529,11 @@ class Padding:
             None if not self.end else self.end.serialized(),
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Padding):
+            return NotImplemented
         return (
-            other
-            and type(self) == type(other)
-            and self.before == other.before
+            self.before == other.before
             and self.after == other.after
             and self.start == other.start
             and self.end == other.end
@@ -592,6 +608,7 @@ class Layout:
         alignment=None,
         webvtt_positioning=None,
         writing_direction=None,
+        position_alignment=None,
         inherit_from=None,
     ):
         """
@@ -617,6 +634,10 @@ class Layout:
         :type writing_direction: WritingDirectionEnum
         :param writing_direction: WebVTT vertical writing direction (rl or lr).
 
+        :type position_alignment: PositionAlignmentEnum
+        :param position_alignment: Which edge of the cue box the position
+            percentage anchors to (line-left, center, or line-right).
+
         :type inherit_from: Layout
         :param inherit_from: A Layout with the positioning parameters to be
             used if not specified by the positioning arguments,
@@ -628,6 +649,7 @@ class Layout:
         self.alignment = alignment
         self.webvtt_positioning = webvtt_positioning
         self.writing_direction = writing_direction
+        self.position_alignment = position_alignment
 
         if inherit_from:
             for attr_name in [
@@ -636,6 +658,7 @@ class Layout:
                 "padding",
                 "alignment",
                 "writing_direction",
+                "position_alignment",
             ]:
                 attr = getattr(self, attr_name)
                 if not attr:
@@ -650,6 +673,7 @@ class Layout:
                 self.alignment,
                 self.webvtt_positioning,
                 self.writing_direction,
+                self.position_alignment,
             )
         )
 
@@ -667,16 +691,19 @@ class Layout:
             None if not self.padding else self.padding.serialized(),
             None if not self.alignment else self.alignment.serialized(),
             self.writing_direction,
+            self.position_alignment,
         )
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Layout):
+            return NotImplemented
         return (
-            type(self) == type(other)
-            and self.origin == other.origin
+            self.origin == other.origin
             and self.extent == other.extent
             and self.padding == other.padding
             and self.alignment == other.alignment
             and self.writing_direction == other.writing_direction
+            and self.position_alignment == other.position_alignment
         )
 
     def __hash__(self):
@@ -686,6 +713,7 @@ class Layout:
             + hash(self.padding) * 13
             + hash(self.alignment) * 5
             + hash(self.writing_direction) * 19
+            + hash(self.position_alignment) * 23
             + 17
         )
 
@@ -706,6 +734,7 @@ class Layout:
         params = {
             "alignment": self.alignment,
             "writing_direction": self.writing_direction,
+            "position_alignment": self.position_alignment,
         }
         for attr_name in ["origin", "extent", "padding"]:
             attr = getattr(self, attr_name)
@@ -720,6 +749,10 @@ class Layout:
         technically valid but contain inconsistent settings that may cause
         long captions to be cut out of the screen.
 
+        When position_alignment is set, the origin is first adjusted so that
+        origin.x represents the true left edge of the cue box (the W3C spec
+        allows the position to anchor to center or right edge).
+
         ATTENTION: This must be called on relativized objects (such as the one
         returned by as_percentage_of). All units are presumed to be percentages.
         """
@@ -732,28 +765,56 @@ class Layout:
         ):
             return self
 
-        if self.origin.x.value >= 90 or self.origin.y.value >= 95:
+        origin = self._resolve_position_alignment()
+
+        if origin.x.value >= 90 or origin.y.value >= 95:
             return self
 
-        diff_horizontal = Size(90 - self.origin.x.value, UnitEnum.PERCENT)
-        diff_vertical = Size(95 - self.origin.y.value, UnitEnum.PERCENT)
+        diff_horizontal = Size(90 - origin.x.value, UnitEnum.PERCENT)
+        diff_vertical = Size(95 - origin.y.value, UnitEnum.PERCENT)
 
         if not self.extent:
             new_extent = Stretch(diff_horizontal, diff_vertical)
         else:
-            new_extent = self._corrected_extent(diff_horizontal, diff_vertical)
+            new_extent = self._corrected_extent_from(
+                origin, diff_horizontal, diff_vertical
+            )
 
         return Layout(
-            origin=self.origin,
+            origin=origin,
             extent=new_extent,
             padding=self.padding,
             alignment=self.alignment,
             writing_direction=self.writing_direction,
         )
 
-    def _corrected_extent(self, diff_horizontal, diff_vertical):
+    def _resolve_position_alignment(self):
+        """Adjust origin.x based on position_alignment and extent width.
+
+        The VTT reader always stores the ``position`` setting in origin.x
+        and ``size`` in extent.horizontal, regardless of writing direction.
+        This method adjusts origin.x so it represents the true left edge
+        of the cue box.
+
+        Returns a new Point (or self.origin unchanged for LINE_LEFT/None).
+        """
+        if not self.position_alignment or not self.extent:
+            return self.origin
+
+        width = self.extent.horizontal.value
+
+        if self.position_alignment == PositionAlignmentEnum.CENTER:
+            adjusted_x = max(0, self.origin.x.value - width / 2)
+        elif self.position_alignment == PositionAlignmentEnum.LINE_RIGHT:
+            adjusted_x = max(0, self.origin.x.value - width)
+        else:
+            return self.origin
+
+        return Point(Size(adjusted_x, UnitEnum.PERCENT), self.origin.y)
+
+    def _corrected_extent_from(self, origin, diff_horizontal, diff_vertical):
         """Return extent clamped so origin + extent doesn't exceed the screen."""
-        bottom_right = self.origin.add_stretch(self.extent)
+        bottom_right = origin.add_stretch(self.extent)
 
         if (
             bottom_right.x.unit != UnitEnum.PERCENT

--- a/pycaption/webvtt/constants.py
+++ b/pycaption/webvtt/constants.py
@@ -6,7 +6,7 @@ docstrings below each pattern explain what they capture and give examples.
 
 import re
 
-from ..geometry import HorizontalAlignmentEnum
+from ..geometry import HorizontalAlignmentEnum, PositionAlignmentEnum
 
 TIMING_LINE_PATTERN = re.compile(r"^(\S+)\s+-->\s+(\S+)(?:\s+(.*?))?\s*$")
 """
@@ -101,6 +101,15 @@ ALIGN_SETTING_MAP = {
 }
 """Reverse mapping from WebVTT ``align`` setting strings to internal
 HorizontalAlignmentEnum values (used by the reader)."""
+
+POSITION_ALIGN_MAP = {
+    "line-left": PositionAlignmentEnum.LINE_LEFT,
+    "center": PositionAlignmentEnum.CENTER,
+    "line-right": PositionAlignmentEnum.LINE_RIGHT,
+    "start": PositionAlignmentEnum.LINE_LEFT,
+    "end": PositionAlignmentEnum.LINE_RIGHT,
+}
+"""Maps WebVTT positionAlign qualifier strings to PositionAlignmentEnum."""
 
 
 def _is_note_start(line):

--- a/pycaption/webvtt/reader.py
+++ b/pycaption/webvtt/reader.py
@@ -32,6 +32,7 @@ from .constants import (
     KNOWN_TAGS,
     LINE_GRID_SIZE,
     LINE_HEIGHT_VH,
+    POSITION_ALIGN_MAP,
     REGION_ANCHOR_PATTERN,
     REGION_SETTING_PATTERN,
     STYLE_SELECTOR_PATTERN,
@@ -155,7 +156,9 @@ class WebVTTReader(BaseReader):
         self._resolve_cue_styles(captions, styles)
 
         caption_set = CaptionSet(
-            {lang: captions}, styles=styles, regions=self._regions_raw,
+            {lang: captions},
+            styles=styles,
+            regions=self._regions_raw,
             visual_alignment_default=HorizontalAlignmentEnum.CENTER,
         )
 
@@ -233,32 +236,15 @@ class WebVTTReader(BaseReader):
         Transitions: skip NOTE/STYLE/REGION blocks → detect timing line →
         accumulate cue text → finalize cue on blank line.
         """
-        if state.in_note_block:
-            state.in_note_block = line != ""
-            return
-
-        if state.in_style_block:
-            state.in_style_block = line != ""
-            return
-
-        if state.in_region_block:
-            state.in_region_block = line != ""
+        if state.in_note_block or state.in_style_block or state.in_region_block:
+            self._continue_skip_block(line, state)
             return
 
         if self._check_block_start(line, state):
             return
 
         if "-->" in line:
-            if state.pending_id is not None:
-                cue_id = state.pending_id
-                state.pending_id = None
-                if cue_id in state.seen_ids:
-                    warnings.warn(
-                        f"Duplicate cue identifier '{cue_id}' (line {line_index}).",
-                        CaptionReadWarning,
-                        stacklevel=4,
-                    )
-                state.seen_ids.add(cue_id)
+            self._consume_pending_id(state, line_index)
             state.found_timing = True
             last_start_time = captions[-1].start if captions else 0
             state.start, state.end, state.layout_info = self._read_timing(
@@ -278,10 +264,22 @@ class WebVTTReader(BaseReader):
             self._finalize_cue(state, captions)
             return
 
-        if state.found_timing and line != "":
-            if state.nodes:
-                state.nodes.append(CaptionNode.create_break())
-            state.nodes.extend(self._parse_cue_text(line, state.open_tags))
+        if not state.found_timing or line == "":
+            return
+        if state.nodes:
+            state.nodes.append(CaptionNode.create_break())
+        state.nodes.extend(self._parse_cue_text(line, state.open_tags))
+
+    @staticmethod
+    def _continue_skip_block(line, state):
+        """Keep skipping lines in a NOTE/STYLE/REGION block until blank."""
+        still_in_block = line != ""
+        if state.in_note_block:
+            state.in_note_block = still_in_block
+        elif state.in_style_block:
+            state.in_style_block = still_in_block
+        else:
+            state.in_region_block = still_in_block
 
     @staticmethod
     def _check_block_start(line, state):
@@ -304,6 +302,21 @@ class WebVTTReader(BaseReader):
             state.pending_id = None
             return True
         return False
+
+    @staticmethod
+    def _consume_pending_id(state, line_index):
+        """Register the pending cue ID (if any) and warn on duplicates."""
+        if state.pending_id is None:
+            return
+        cue_id = state.pending_id
+        state.pending_id = None
+        if cue_id in state.seen_ids:
+            warnings.warn(
+                f"Duplicate cue identifier '{cue_id}' (line {line_index}).",
+                CaptionReadWarning,
+                stacklevel=5,
+            )
+        state.seen_ids.add(cue_id)
 
     def _finalize_cue(self, state, captions):
         """Close the current cue, append it to captions, and reset state
@@ -437,8 +450,10 @@ class WebVTTReader(BaseReader):
 
         if groups[2]:
             return microseconds(
-                groups[0], groups[1],
-                groups[2].replace(":", ""), groups[3],
+                groups[0],
+                groups[1],
+                groups[2].replace(":", ""),
+                groups[3],
             )
         return microseconds(0, groups[0], groups[1], groups[3])
 
@@ -804,12 +819,10 @@ class WebVTTReader(BaseReader):
             name, value = match.group(1), match.group(2)
             parsed[name] = value
 
-        position_value, _ = WebVTTReader._split_alignment(
+        position_value, position_align = WebVTTReader._split_alignment(
             parsed.get("position", "")
         )
-        line_value, _ = WebVTTReader._split_alignment(
-            parsed.get("line", "")
-        )
+        line_value, _ = WebVTTReader._split_alignment(parsed.get("line", ""))
 
         origin_x = WebVTTReader._parse_percent_value(position_value)
         origin_y = WebVTTReader._parse_line_value(line_value)
@@ -817,6 +830,9 @@ class WebVTTReader(BaseReader):
         alignment = WebVTTReader._parse_align_value(parsed.get("align", ""))
         writing_direction = WebVTTReader._parse_vertical_value(
             parsed.get("vertical", "")
+        )
+        pos_alignment = (
+            POSITION_ALIGN_MAP.get(position_align) if position_align else None
         )
 
         origin = None
@@ -833,6 +849,7 @@ class WebVTTReader(BaseReader):
             extent=extent,
             alignment=alignment,
             writing_direction=writing_direction,
+            position_alignment=pos_alignment,
             webvtt_positioning=cue_settings,
             inherit_from=inherit_from,
         )

--- a/tests/test_dfxp.py
+++ b/tests/test_dfxp.py
@@ -182,6 +182,7 @@ class TestDFXPReader(ReaderTestingMixIn):
                 None,
                 (HorizontalAlignmentEnum.START, VerticalAlignmentEnum.BOTTOM),
                 None,
+                None,
             ),
             (
                 ((40, UnitEnum.PERCENT), (40, UnitEnum.PERCENT)),
@@ -189,12 +190,14 @@ class TestDFXPReader(ReaderTestingMixIn):
                 None,
                 (HorizontalAlignmentEnum.START, VerticalAlignmentEnum.BOTTOM),
                 None,
+                None,
             ),
             (
                 ((10, UnitEnum.PERCENT), (70, UnitEnum.PERCENT)),
                 None,
                 None,
                 (HorizontalAlignmentEnum.START, VerticalAlignmentEnum.BOTTOM),
+                None,
                 None,
             ),
         ]

--- a/tests/test_scc.py
+++ b/tests/test_scc.py
@@ -172,12 +172,14 @@ class TestSCCReader(ReaderTestingMixIn):
                 None,
                 (HorizontalAlignmentEnum.LEFT, VerticalAlignmentEnum.TOP),
                 None,
+                None,
             ),
             (
                 ((10.0, UnitEnum.PERCENT), (83.0, UnitEnum.PERCENT)),
                 None,
                 None,
                 (HorizontalAlignmentEnum.LEFT, VerticalAlignmentEnum.TOP),
+                None,
                 None,
             ),
         ]
@@ -196,6 +198,7 @@ class TestSCCReader(ReaderTestingMixIn):
                         None,
                         (HorizontalAlignmentEnum.LEFT, VerticalAlignmentEnum.TOP),
                         None,
+                        None,
                     )
                 ]
             },
@@ -206,6 +209,7 @@ class TestSCCReader(ReaderTestingMixIn):
                         None,
                         None,
                         (HorizontalAlignmentEnum.LEFT, VerticalAlignmentEnum.TOP),
+                        None,
                         None,
                     )
                 ]

--- a/tests/test_webvtt.py
+++ b/tests/test_webvtt.py
@@ -8,6 +8,7 @@ from pycaption import (
     CaptionReadSyntaxError,
     CaptionReadWarning,
     DFXPReader,
+    DFXPWriter,
     SAMIReader,
     WebVTTReader,
     WebVTTWriter,
@@ -15,6 +16,7 @@ from pycaption import (
 from pycaption.base import CaptionNode
 from pycaption.geometry import (
     HorizontalAlignmentEnum,
+    PositionAlignmentEnum,
     Size,
     UnitEnum,
     WritingDirectionEnum,
@@ -819,6 +821,135 @@ Hello
         layout = cue.layout_info
 
         assert layout.origin.x == Size(50, UnitEnum.PERCENT)
+        assert layout.position_alignment == PositionAlignmentEnum.LINE_LEFT
+
+    def test_position_alignment_center_stored(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 position:50%,center line:80%\n"
+            "Hello\n"
+        )
+        captions = self.reader.read(vtt)
+        cue = captions.get_captions("en-US")[0]
+        layout = cue.layout_info
+
+        assert layout.position_alignment == PositionAlignmentEnum.CENTER
+        assert layout.origin.x == Size(50, UnitEnum.PERCENT)
+
+    def test_position_alignment_line_right_stored(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 position:70%,line-right line:10%\n"
+            "Hello\n"
+        )
+        captions = self.reader.read(vtt)
+        cue = captions.get_captions("en-US")[0]
+        layout = cue.layout_info
+
+        assert layout.position_alignment == PositionAlignmentEnum.LINE_RIGHT
+        assert layout.origin.x == Size(70, UnitEnum.PERCENT)
+
+    def test_position_alignment_none_when_unspecified(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 position:50% line:80%\n"
+            "Hello\n"
+        )
+        captions = self.reader.read(vtt)
+        cue = captions.get_captions("en-US")[0]
+        layout = cue.layout_info
+
+        assert layout.position_alignment is None
+
+    def test_position_alignment_center_adjusts_origin_in_dfxp(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 "
+            "position:50%,center line:80% size:60%\n"
+            "Hello\n"
+        )
+        captions = self.reader.read(vtt)
+        output = DFXPWriter().write(captions)
+        dfxp_captions = DFXPReader().read(output)
+        cue = dfxp_captions.get_captions("en-US")[0]
+
+        assert cue.layout_info.origin.x == Size(20.0, UnitEnum.PERCENT)
+
+    def test_position_alignment_line_right_adjusts_origin_in_dfxp(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 "
+            "position:80%,line-right line:10% size:60%\n"
+            "Hello\n"
+        )
+        captions = self.reader.read(vtt)
+        output = DFXPWriter().write(captions)
+        dfxp_captions = DFXPReader().read(output)
+        cue = dfxp_captions.get_captions("en-US")[0]
+
+        assert cue.layout_info.origin.x == Size(20.0, UnitEnum.PERCENT)
+
+    def test_position_alignment_center_clamps_to_zero_in_dfxp(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 "
+            "position:10%,center line:10% size:50%\n"
+            "Hello\n"
+        )
+        captions = self.reader.read(vtt)
+        output = DFXPWriter().write(captions)
+        dfxp_captions = DFXPReader().read(output)
+        cue = dfxp_captions.get_captions("en-US")[0]
+
+        assert cue.layout_info.origin.x == Size(0.0, UnitEnum.PERCENT)
+
+    def test_position_alignment_start_maps_to_line_left(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 position:40%,start line:10%\n"
+            "Hello\n"
+        )
+        captions = self.reader.read(vtt)
+        cue = captions.get_captions("en-US")[0]
+
+        assert cue.layout_info.position_alignment == PositionAlignmentEnum.LINE_LEFT
+
+    def test_position_alignment_vertical_rl_adjusts_x(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 "
+            "vertical:rl position:50%,center line:20% size:40%\n"
+            "Hello\n"
+        )
+        captions = self.reader.read(vtt)
+        output = DFXPWriter().write(captions)
+        dfxp_captions = DFXPReader().read(output)
+        cue = dfxp_captions.get_captions("en-US")[0]
+
+        assert cue.layout_info.origin.x == Size(30.0, UnitEnum.PERCENT)
+        assert cue.layout_info.origin.y == Size(20.0, UnitEnum.PERCENT)
+
+    def test_multiple_cues_with_different_position_alignments(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:03.000 "
+            "position:50%,line-left line:10% size:40%\n"
+            "Left-anchored\n\n"
+            "00:00:04.000 --> 00:00:06.000 "
+            "position:50%,center line:10% size:40%\n"
+            "Center-anchored\n\n"
+            "00:00:07.000 --> 00:00:09.000 "
+            "position:80%,line-right line:10% size:60%\n"
+            "Right-anchored\n"
+        )
+        captions = self.reader.read(vtt)
+        output = DFXPWriter().write(captions)
+        dfxp_captions = DFXPReader().read(output)
+        cues = dfxp_captions.get_captions("en-US")
+
+        assert cues[0].layout_info.origin.x == Size(50.0, UnitEnum.PERCENT)
+        assert cues[1].layout_info.origin.x == Size(30.0, UnitEnum.PERCENT)
+        assert cues[2].layout_info.origin.x == Size(20.0, UnitEnum.PERCENT)
 
     def test_line_with_alignment_subvalue(self):
         vtt = "WEBVTT\n\n" "00:00:01.000 --> 00:00:03.000 line:80%,center\n" "Hello\n"


### PR DESCRIPTION

  - Fix incorrect `origin.x` when converting WebVTT cues with `position:N%,center` or `position:N%,line-right` to DFXP/SCC. Previously the position percentage was stored directly as `origin.x`, which is only correct for `line-left`/`start`. For example, `position:50%,center` with `size:60%` now produces `origin.x = 20%` instead of `50%`.
  - Add `PositionAlignmentEnum` and `Layout.position_alignment` field so the qualifier is preserved through the read→write pipeline.
  - `fit_to_screen()` resolves position alignment before computing the output region; result is clamped to 0% to prevent negative origins.