### PR TITLE
OCTO-11575 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
     base_row 15). The writer now stacks lines upward from row 15 so each
     line gets a distinct PAC code and survives a roundtrip without merging.
 
+  - Fix ``SCCWriter`` producing negative-duration cues when dense input
+    (cue spacing < code transmission time) causes start-time drift beyond
+    the original end time. The writer now suppresses the clear command
+    rather than emitting an invalid timestamp.
+
   - Fix ``SAMIWriter`` emitting ``class=""`` when the classes list is empty
     (e.g. from YouTube auto-generated VTT files with bare ``<c>`` karaoke
     tags). The writer now skips the class attribute entirely for empty lists.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,11 @@ Changelog
 ---------
 2.3.7
 ^^^^^^
+  - Fix ``SCCWriter`` merging multi-line captions into a single line when
+    the source positions them at the bottom of the screen (Y >= 86%,
+    base_row 15). The writer now stacks lines upward from row 15 so each
+    line gets a distinct PAC code and survives a roundtrip without merging.
+
   - Fix ``SAMIWriter`` emitting ``class=""`` when the classes list is empty
     (e.g. from YouTube auto-generated VTT files with bare ``<c>`` karaoke
     tags). The writer now skips the class attribute entirely for empty lists.

--- a/pycaption/scc/writer.py
+++ b/pycaption/scc/writer.py
@@ -99,6 +99,7 @@ class SCCWriter(BaseWriter):
         codes = self._encode_all(classified)
         codes = self._adjust_timing(codes)
         codes = self._deduplicate_timestamps(codes)
+        codes = self._clamp_end_times(codes)
         output += self._render_mixed(codes)
 
         return output
@@ -193,6 +194,17 @@ class SCCWriter(BaseWriter):
                     start += MICROSECONDS_PER_CODEWORD
                 codes[index] = (code, start, end, mode, depth)
             last_emitted_frame = self._microseconds_to_frame(start)
+        return codes
+
+    @staticmethod
+    def _clamp_end_times(codes):
+        """Suppress end times that drift behind start after timing adjustments.
+        When dense cues push start forward beyond the original end, emit no
+        clear command (end=None) rather than producing an invalid negative-
+        duration cue."""
+        for index, (code, start, end, mode, depth) in enumerate(codes):
+            if end is not None and end <= start:
+                codes[index] = (code, start, None, mode, depth)
         return codes
 
     def _render_mixed(self, codes):

--- a/pycaption/scc/writer.py
+++ b/pycaption/scc/writer.py
@@ -225,12 +225,7 @@ class SCCWriter(BaseWriter):
         code_tokens = code.split()
 
         if len(code_tokens) <= max_payload:
-            return (
-                f"{ts}\t"
-                "94ae 94ae 9420 9420 "
-                f"{code}"
-                "942c 942c 942f 942f\n\n"
-            )
+            return f"{ts}\t" "94ae 94ae 9420 9420 " f"{code}" "942c 942c 942f 942f\n\n"
 
         output = ""
         offset = 0
@@ -243,11 +238,7 @@ class SCCWriter(BaseWriter):
             is_last = offset + max_payload >= len(code_tokens)
             if is_last:
                 line = line + ["942c", "942c", "942f", "942f"]
-            output += (
-                f"{self._format_timestamp(start)}\t"
-                + " ".join(line)
-                + "\n\n"
-            )
+            output += f"{self._format_timestamp(start)}\t" + " ".join(line) + "\n\n"
             offset += max_payload
             if not is_last:
                 start += MICROSECONDS_PER_CODEWORD
@@ -329,6 +320,7 @@ class SCCWriter(BaseWriter):
                 base_row = max(1, min(15, round((y.value - 5) / 90.0 * 15) + 1))
             else:
                 base_row = 15
+            base_row = max(1, min(base_row, 16 - num_lines))
             row = base_row + line_index
             return min(row, 15)
         return max(1, min(15, 16 - num_lines + line_index))

--- a/tests/test_scc_writer.py
+++ b/tests/test_scc_writer.py
@@ -185,6 +185,30 @@ class TestSCCWriterOverlappingCues:
         # (only the last cue gets a clear-screen at its end time)
         assert len(clear_lines) <= 1
 
+    def test_dense_cues_never_produce_negative_duration(self):
+        """When many dense cues push start times forward via timing
+        adjustments, the end time must never be less than the start."""
+        lines = ["WEBVTT", ""]
+        for i in range(20):
+            start_ms = 1000 + i * 200
+            end_ms = start_ms + 150
+            s, e = start_ms / 1000, end_ms / 1000
+            lines.append(
+                f"00:00:{int(s):02d}.{int((s % 1) * 1000):03d} --> "
+                f"00:00:{int(e):02d}.{int((e % 1) * 1000):03d}"
+            )
+            lines.append(
+                f"Caption number {i + 1:02d} with a lot of extra "
+                f"text padding here for testing!!"
+            )
+            lines.append("")
+        captions = WebVTTReader().read("\n".join(lines))
+        scc_output = SCCWriter().write(captions)
+        reread = SCCReader().read(scc_output)
+        caps = reread.get_captions(reread.get_languages()[0])
+        for cap in caps:
+            assert cap.end >= cap.start
+
 
 class TestSCCWriterSplitLongCaption:
     def test_split_caption_exceeding_80_tokens(self):

--- a/tests/test_scc_writer.py
+++ b/tests/test_scc_writer.py
@@ -319,6 +319,43 @@ class TestSCCWriterPositioning:
         pac_col_28 = WRITER_PAC_CODES[(15, 28, "plain")]
         assert pac_col_28 in output
 
+    def test_multiline_bottom_stacks_upward(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:04.000 line:100%\n"
+            "This is line one\n"
+            "This is line two\n"
+        )
+        captions = WebVTTReader().read(vtt)
+        scc_output = SCCWriter().write(captions)
+        reread = SCCReader().read(scc_output)
+        caps = reread.get_captions(reread.get_languages()[0])
+        assert caps[0].get_text() == "This is line one\nThis is line two"
+        pac_row_14 = WRITER_PAC_CODES[(14, 0, "plain")]
+        pac_row_15 = WRITER_PAC_CODES[(15, 0, "plain")]
+        assert pac_row_14 in scc_output
+        assert pac_row_15 in scc_output
+
+    def test_three_line_at_86_percent_stacks_upward(self):
+        vtt = (
+            "WEBVTT\n\n"
+            "00:00:01.000 --> 00:00:04.000 line:86%\n"
+            "First line\n"
+            "Second line\n"
+            "Third line\n"
+        )
+        captions = WebVTTReader().read(vtt)
+        scc_output = SCCWriter().write(captions)
+        reread = SCCReader().read(scc_output)
+        caps = reread.get_captions(reread.get_languages()[0])
+        assert caps[0].get_text() == "First line\nSecond line\nThird line"
+        pac_row_13 = WRITER_PAC_CODES[(13, 0, "plain")]
+        pac_row_14 = WRITER_PAC_CODES[(14, 0, "plain")]
+        pac_row_15 = WRITER_PAC_CODES[(15, 0, "plain")]
+        assert pac_row_13 in scc_output
+        assert pac_row_14 in scc_output
+        assert pac_row_15 in scc_output
+
 
 class TestSCCWriterStyles:
     def test_vtt_italic_emits_mid_row_code(self):


### PR DESCRIPTION
## Summary
- Fix SCCWriter merging multi-line captions into a single line when the source positions them at the bottom of the screen (Y >= 86%, base_row 15)
- Clamp base_row in _compute_scc_row so multi-line captions stack upward from row 15, giving each line a distinct PAC code
- Fix SCCWriter producing negative-duration cues from dense input. When cues are packed tightly (spacing < code transmission time), _adjust_timing pushes start forward but leaves end unchanged. This can result in end <= start, producing an invalid negative-duration cue on re-read. Suppress the clear command (end=None) in that case so the cue stays visible until the next one replaces it.
- Add roundtrip tests for 2-line (line:100%) and 3-line (line:86%) bottom-positioned captions
- Add test for dense cues (20 cues, 200ms spacing) never producing negative durations

## Test plan
- [x] 2-line caption at `line:100%` emits PAC codes for rows 14 and 15
- [x] 3-line caption at `line:86%` emits PAC codes for rows 13, 14, and 15
- [x] SCC → SCC roundtrip preserves line breaks
- [x] Single-line at row 15 unchanged
- [x] Mid-screen multi-line captions unaffected
- [x] Dense cues (20 cues, 200ms spacing) produce no negative-duration cues