### PR TITLE
Raise CaptionReadSyntaxError for malformed SRT instead of IndexError/ValueError

### DIFF
--- a/pycaption/srt.py
+++ b/pycaption/srt.py
@@ -6,7 +6,7 @@ from .base import (
     BaseReader, BaseWriter, Caption, CaptionList, CaptionNode, CaptionSet,
     merge_caption_list,
 )
-from .exceptions import CaptionReadNoCaptions
+from .exceptions import CaptionReadNoCaptions, CaptionReadSyntaxError
 from .geometry import HorizontalAlignmentEnum
 
 
@@ -21,6 +21,8 @@ class SRTReader(BaseReader):
         """
         content = self._decode_content(content)
         lines = content.splitlines()
+        if len(lines) < 2:
+            return False
         if lines[0].isdigit() and "-->" in lines[1]:
             return True
         else:
@@ -48,8 +50,17 @@ class SRTReader(BaseReader):
             end_line = self._find_text_line(start_line, lines)
 
             timing = lines[start_line + 1].split("-->")
-            start = self._srttomicro(timing[0].strip(" \r\n"))
-            end = self._srttomicro(timing[1].strip(" \r\n"))
+            if len(timing) != 2:
+                raise CaptionReadSyntaxError(
+                    f"Invalid timing line: {lines[start_line + 1]!r}"
+                )
+            try:
+                start = self._srttomicro(timing[0].strip(" \r\n"))
+                end = self._srttomicro(timing[1].strip(" \r\n"))
+            except (IndexError, ValueError):
+                raise CaptionReadSyntaxError(
+                    f"Invalid timestamp in: {lines[start_line + 1]!r}"
+                )
 
             nodes = []
 

--- a/tests/test_srt.py
+++ b/tests/test_srt.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pycaption import CaptionReadNoCaptions, SRTReader
+from pycaption.exceptions import CaptionReadSyntaxError
 from tests.mixins import ReaderTestingMixIn
 
 
@@ -50,6 +51,22 @@ class TestSRTReader(ReaderTestingMixIn):
         with pytest.raises(CaptionReadNoCaptions) as exc_info:
             self.reader.read(sample_srt_empty)
         assert exc_info.value.args[0] == "empty caption file"
+
+    def test_detection_of_single_line_content(self):
+        # Content with fewer than two lines used to raise IndexError from
+        # lines[1]; detection should just return False.
+        assert self.reader.detect("1") is False
+        assert self.reader.detect("") is False
+
+    def test_malformed_timing_raises_read_error(self):
+        # A timing line missing or with an unparsable timestamp used to raise a
+        # bare IndexError/ValueError; it should be a CaptionReadSyntaxError.
+        for content in (
+            "1\n00:00:01,000 -->\nHi",
+            "1\n00:00:01,000 --> xx:yy\nHi",
+        ):
+            with pytest.raises(CaptionReadSyntaxError):
+                self.reader.read(content)
 
     def test_extra_empty_line(self, sample_srt_blank_lines):
         captions = self.reader.read(sample_srt_blank_lines)


### PR DESCRIPTION
The SRT reader raises bare `IndexError`/`ValueError` on some malformed input instead of a `CaptionRead*` error:

- `SRTReader().detect("1")` -> `IndexError` (reads `lines[1]` without checking there are two lines)
- `SRTReader().read("1\n00:00:01,000 -->\nHi")` -> `IndexError` from an empty end timestamp
- a non-numeric timestamp -> `ValueError`

I made `detect` return `False` for content with fewer than two lines, and `read` validate the `-->` timing line and wrap timestamp parsing so a malformed timing line raises `CaptionReadSyntaxError`. Valid SRT parsing is unchanged.

Added tests for single-line detection and malformed timing; they fail on `main` with IndexError/ValueError and pass with the change, and the rest of the SRT tests still pass. Found it by fuzzing the readers with mutated captions.