### PR TITLE
Raise CaptionReadTimingError for a non-numeric SAMI start time

### DIFF
--- a/pycaption/sami/reader.py
+++ b/pycaption/sami/reader.py
@@ -142,7 +142,12 @@ class SAMIReader(BaseReader):
                 raise CaptionReadTimingError(
                     f"Missing start time on the following line: {p.parent}."
                 )
-            milliseconds = int(float(start_str))
+            try:
+                milliseconds = int(float(start_str))
+            except ValueError:
+                raise CaptionReadTimingError(
+                    f"Invalid start time on the following line: {p.parent}."
+                )
             start = milliseconds * 1000
 
             self._backfill_end_times(captions, start)

--- a/tests/test_sami.py
+++ b/tests/test_sami.py
@@ -50,6 +50,17 @@ class TestSAMIReader(ReaderTestingMixIn):
             "Missing start time on the following line: "
         )
 
+    def test_non_numeric_start(self):
+        # A non-numeric SYNC start attribute used to raise a bare ValueError
+        # from int(float(start_str)); it should be a CaptionReadTimingError.
+        content = "<SAMI><BODY><SYNC Start=abc><P>Hi</P></SYNC></BODY></SAMI>"
+        with pytest.raises(CaptionReadTimingError) as exc_info:
+            self.reader.read(content)
+
+        assert exc_info.value.args[0].startswith(
+            "Invalid start time on the following line: "
+        )
+
     def test_6digit_color_code_from_6digit_input(self, sample_sami):
         caption_set = self.reader.read(sample_sami)
         p_style = caption_set.get_style("p")


### PR DESCRIPTION
The SAMI reader raises a bare `ValueError` when a `<SYNC>` element's `start` attribute is not numeric:

```python
SAMIReader().read("<SAMI><BODY><SYNC Start=abc><P>Hi</P></SYNC></BODY></SAMI>")
# ValueError: could not convert string to float: 'abc'
```

`_translate_lang` does `int(float(start_str))`. A missing start time already raises `CaptionReadTimingError`, so I wrapped the conversion to raise the same error ("Invalid start time ...") for an unparsable one. Valid SAMI is unchanged.

Added a test next to `test_missing_start`; it raises ValueError on `main` and passes with the change. Found it by fuzzing the readers with mutated captions.