### PR TITLE
Raise CaptionReadSyntaxError for malformed SRT instead of IndexError

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,12 @@ Changelog
     ``class`` (or ``lang``) attribute. Such attributes carry no language
     information and are now ignored.
 
+  - Fix ``SRTReader`` raising a bare ``IndexError`` or ``ValueError`` on
+    malformed input (a caption number with no timing line after it, a timing
+    line missing ``-->``, or a timestamp with missing or non-numeric fields).
+    The reader now raises ``CaptionReadSyntaxError`` like its other read
+    errors.
+
 2.3.8
 ^^^^^^
   - Fix ``WebVTTReader`` silently discarding the ``position:`` cue setting

--- a/pycaption/srt.py
+++ b/pycaption/srt.py
@@ -21,6 +21,8 @@ class SRTReader(BaseReader):
         """
         content = self._decode_content(content)
         lines = content.splitlines()
+        if len(lines) < 2:
+            return False
         if lines[0].isdigit() and "-->" in lines[1]:
             return True
         else:

--- a/pycaption/srt.py
+++ b/pycaption/srt.py
@@ -6,7 +6,7 @@ from .base import (
     BaseReader, BaseWriter, Caption, CaptionList, CaptionNode, CaptionSet,
     merge_caption_list,
 )
-from .exceptions import CaptionReadNoCaptions
+from .exceptions import CaptionReadNoCaptions, CaptionReadSyntaxError
 from .geometry import HorizontalAlignmentEnum
 
 
@@ -47,6 +47,11 @@ class SRTReader(BaseReader):
 
             end_line = self._find_text_line(start_line, lines)
 
+            if start_line + 1 >= len(lines) or "-->" not in lines[start_line + 1]:
+                raise CaptionReadSyntaxError(
+                    "Missing or malformed timing line after caption number "
+                    f"{lines[start_line]!r}."
+                )
             timing = lines[start_line + 1].split("-->")
             start = self._srttomicro(timing[0].strip(" \r\n"))
             end = self._srttomicro(timing[1].strip(" \r\n"))
@@ -81,15 +86,18 @@ class SRTReader(BaseReader):
     def _srttomicro(stamp):
         """Convert an SRT timestamp (HH:MM:SS,mmm) to microseconds."""
         timesplit = stamp.split(":")
-        if "," not in timesplit[2]:
-            timesplit[2] += ",000"
-        secsplit = timesplit[2].split(",")
-        microseconds = (
-            int(timesplit[0]) * 3600000000
-            + int(timesplit[1]) * 60000000
-            + int(secsplit[0]) * 1000000
-            + int(secsplit[1]) * 1000
-        )
+        try:
+            if "," not in timesplit[2]:
+                timesplit[2] += ",000"
+            secsplit = timesplit[2].split(",")
+            microseconds = (
+                int(timesplit[0]) * 3600000000
+                + int(timesplit[1]) * 60000000
+                + int(secsplit[0]) * 1000000
+                + int(secsplit[1]) * 1000
+            )
+        except (IndexError, ValueError):
+            raise CaptionReadSyntaxError(f"Invalid SRT timestamp: {stamp!r}.")
 
         return microseconds
 

--- a/tests/test_srt.py
+++ b/tests/test_srt.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pycaption import CaptionReadNoCaptions, SRTReader
+from pycaption.exceptions import CaptionReadSyntaxError
 from tests.mixins import ReaderTestingMixIn
 
 
@@ -50,6 +51,20 @@ class TestSRTReader(ReaderTestingMixIn):
         with pytest.raises(CaptionReadNoCaptions) as exc_info:
             self.reader.read(sample_srt_empty)
         assert exc_info.value.args[0] == "empty caption file"
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            "1\n",  # caption number with no timing line following
+            "1\n2\n",  # a second number where the timing line should be
+            "1\n00:00:01,000\ntext\n",  # timing line without an arrow
+            "1\n00:x:01,000 --> 00:00:04,000\ntext\n",  # non-numeric timestamp
+            "1\n00:01,000 --> 00:04,000\ntext\n",  # timestamp missing a field
+        ],
+    )
+    def test_malformed_input_raises_read_error(self, content):
+        with pytest.raises(CaptionReadSyntaxError):
+            self.reader.read(content)
 
     def test_extra_empty_line(self, sample_srt_blank_lines):
         captions = self.reader.read(sample_srt_blank_lines)

--- a/tests/test_srt.py
+++ b/tests/test_srt.py
@@ -47,6 +47,10 @@ class TestSRTReader(ReaderTestingMixIn):
         assert paragraphs[-3].get_text() == "NUMBER  IS  662-429-84-77."
         assert paragraphs[-1].get_text() == "3"
 
+    @pytest.mark.parametrize("content", ["1", "", "abc"])
+    def test_detect_returns_false_for_short_content(self, content):
+        assert self.reader.detect(content) is False
+
     def test_empty_file(self, sample_srt_empty):
         with pytest.raises(CaptionReadNoCaptions) as exc_info:
             self.reader.read(sample_srt_empty)


### PR DESCRIPTION
`SRTReader().read()` leaks a bare `IndexError` (or `ValueError`) on a few kinds of malformed SRT, rather than one of the `CaptionRead*` errors callers expect to catch:

```python
from pycaption import SRTReader
SRTReader().read("1\n")               # IndexError: list index out of range
SRTReader().read("1\n00:x:01,000 --> 00:00:04,000\ntext\n")  # ValueError
```

The first is a caption number with no timing line after it, the second a non-numeric timestamp. A timing line missing the `-->` arrow, or a stamp with too few fields, hit the same paths. I guarded the timing-line lookup and wrapped the timestamp parsing so they raise `CaptionReadSyntaxError` like the other readers do. Added a parametrized test for the malformed cases; full suite still passes.
