### PR TITLE
Handle malformed SAMI without leaking ValueError/AttributeError

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,5 +1,15 @@
 Changelog
 ---------
+2.3.9
+^^^^^^
+  - Fix ``SAMIReader`` raising a bare ``ValueError`` when a ``<sync>`` tag's
+    ``start`` attribute is present but not numeric. It now raises
+    ``CaptionReadTimingError`` like the missing-start case.
+
+  - Fix ``SAMIReader`` raising ``AttributeError`` when a tag has a valueless
+    ``class`` (or ``lang``) attribute. Such attributes carry no language
+    information and are now ignored.
+
 2.3.8
 ^^^^^^
   - Fix ``WebVTTReader`` silently discarding the ``position:`` cue setting

--- a/pycaption/sami/parser.py
+++ b/pycaption/sami/parser.py
@@ -174,6 +174,10 @@ class SAMIParser(HTMLParser):
         :rtype: str | None
         """
         for attr, value in attrs:
+            if value is None:
+                # A valueless attribute (e.g. a bare ``class``) carries no
+                # language information; skip it rather than crashing.
+                continue
             if attr.lower() == "lang":
                 return value[:2]
             if attr.lower() == "class":

--- a/pycaption/sami/reader.py
+++ b/pycaption/sami/reader.py
@@ -142,7 +142,13 @@ class SAMIReader(BaseReader):
                 raise CaptionReadTimingError(
                     f"Missing start time on the following line: {p.parent}."
                 )
-            milliseconds = int(float(start_str))
+            try:
+                milliseconds = int(float(start_str))
+            except ValueError:
+                raise CaptionReadTimingError(
+                    f"Invalid start time {start_str!r} on the following "
+                    f"line: {p.parent}."
+                )
             start = milliseconds * 1000
 
             self._backfill_end_times(captions, start)

--- a/tests/test_sami.py
+++ b/tests/test_sami.py
@@ -50,6 +50,26 @@ class TestSAMIReader(ReaderTestingMixIn):
             "Missing start time on the following line: "
         )
 
+    @pytest.mark.parametrize("start", ["abc", "1rt=1000", ""])
+    def test_non_numeric_start_raises_timing_error(self, start):
+        content = (
+            f"<SAMI><BODY><SYNC Start={start}>"
+            "<P>hi</P></SYNC></BODY></SAMI>"
+        )
+        with pytest.raises(CaptionReadTimingError):
+            self.reader.read(content)
+
+    def test_valueless_class_attribute_is_ignored(self):
+        # A bare ``class`` attribute (no value) used to crash _find_lang with
+        # AttributeError; it should just be treated as carrying no language.
+        content = (
+            "<SAMI><BODY><SYNC Start=1000>"
+            "<P Class>hi</P></SYNC></BODY></SAMI>"
+        )
+        caption_set = self.reader.read(content)
+        langs = caption_set.get_languages()
+        assert caption_set.get_captions(langs[0])[0].get_text() == "hi"
+
     def test_6digit_color_code_from_6digit_input(self, sample_sami):
         caption_set = self.reader.read(sample_sami)
         p_style = caption_set.get_style("p")


### PR DESCRIPTION
Two kinds of malformed SAMI make `SAMIReader().read()` leak a raw exception instead of one of the `CaptionRead*` errors:

```python
from pycaption import SAMIReader
SAMIReader().read("<SAMI><BODY><SYNC Start=abc><P>hi</P></SYNC></BODY></SAMI>")  # ValueError
SAMIReader().read("<SAMI><BODY><SYNC Start=1000><P Class>hi</P></SYNC></BODY></SAMI>")  # AttributeError
```

The first is a non-numeric `start` attribute hitting `int(float(start))`. The second is a valueless `class` attribute (HTMLParser gives it a value of `None`), which `_find_lang` then calls `.lower()` on. A bare `lang` attribute trips the same `None` path via `value[:2]`.

Non-numeric start now raises `CaptionReadTimingError`, matching the missing-start check right next to it. A valueless class/lang attribute carries no language info, so it's just skipped. Added tests for both; the SAMI suite and full suite still pass.
